### PR TITLE
Enable smooth scrolling for users with no `reduce-motion` preference

### DIFF
--- a/app/assets/css/base.css
+++ b/app/assets/css/base.css
@@ -1,3 +1,9 @@
 :root {
   --hn-nav-height: 69px;
 }
+
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}


### PR DESCRIPTION
Allows the browser to handle animated scrolling for us: https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior