### PR TITLE
Add current CoC to the Conduct page

### DIFF
--- a/app/templates/pages/conduct.html.erb
+++ b/app/templates/pages/conduct.html.erb
@@ -1,3 +1,89 @@
 <% content_for :title, "Code of conduct" %>
 
-<h1>Code of conduct</h1>
+<h1>Contributor Covenant Code of Conduct</h1>
+
+<h2>Our Pledge</h2>
+<p>We pledge to make our community welcoming, safe, and equitable for all.</p>
+<p>We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.</p>
+
+<h2>Encouraged Behaviors</h2>
+<p>While acknowledging differences in social norms, we all strive to meet our community’s expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.</p>
+<p>With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:</p>
+<ol>
+  <li>Respecting the <strong>purpose of our community</strong>, our activities, and our ways of gathering.</li>
+  <li>Engaging <strong>kindly and honestly</strong> with others.</li>
+  <li>Respecting <strong>different viewpoints</strong> and experiences.</li>
+  <li><strong>Taking responsibility</strong> for our actions and contributions.</li>
+  <li>Gracefully giving and accepting <strong>constructive feedback</strong>.</li>
+  <li>Committing to <strong>repairing harm</strong> when it occurs.</li>
+  <li>Behaving in other ways that promote and sustain the <strong>well-being of our community</strong>.</li>
+</ol>
+
+<h2>Restricted Behaviors</h2>
+<p>We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.</p>
+<ol>
+  <li><strong>Harassment.</strong> Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.</li>
+  <li><strong>Character attacks.</strong> Making insulting, demeaning, or pejorative comments directed at a community member or group of people.</li>
+  <li><strong>Stereotyping or discrimination.</strong> Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.</li>
+  <li><strong>Sexualization.</strong> Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.</li>
+  <li><strong>Violating confidentiality</strong>. Sharing or acting on someone’s personal or private information without their permission.</li>
+  <li><strong>Endangerment.</strong> Causing, encouraging, or threatening violence or other harm toward any person or group.</li>
+  <li>Behaving in other ways that <strong>threaten the well-being</strong> of our community.</li>
+</ol>
+
+<h3>Other Restrictions</h3>
+<ol>
+  <li><strong>Misleading identity.</strong> Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.</li>
+  <li><strong>Failing to credit sources.</strong> Not properly crediting the sources of content you contribute.</li>
+  <li><strong>Promotional materials</strong>. Sharing marketing or other commercial content in a way that is outside the norms of the community.</li>
+  <li><strong>Irresponsible communication.</strong> Failing to responsibly present content which includes, links or describes any other restricted behaviors.</li>
+</ol>
+
+<h2>Reporting an Issue</h2>
+<p>Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.</p>
+<p>When an incident does occur, it is important to report it promptly. To report a possible violation, <strong>email admin@hanamirb.org</strong>.</p>
+<p>Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.</p>
+
+<h2>Addressing and Repairing Harm</h2>
+<p>If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident’s impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.</p>
+<ol>
+  <li>
+    Warning
+    <ol>
+      <li>Event: A violation involving a single incident or series of incidents.</li>
+      <li>Consequence: A private, written warning from the Community Moderators.</li>
+      <li>Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.</li>
+    </ol>
+  </li>
+  <li>
+    Temporarily Limited Activities
+    <ol>
+      <li>Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.</li>
+      <li>Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.</li>
+      <li>Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.</li>
+    </ol>
+  </li>
+  <li>
+    Temporary Suspension
+    <ol>
+      <li>Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.</li>
+      <li>Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.</li>
+      <li>Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.</li>
+    </ol>
+  </li>
+  <li>
+    Permanent Ban
+    <ol>
+      <li>Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.</li>
+      <li>Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.</li>
+      <li>Repair: There is no possible repair in cases of this severity.</li>
+    </ol>
+  </li>
+</ol>
+<p>This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.</p>
+
+<h2>Scope</h2>
+<p>This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.</p>
+
+<h2>Attribution</h2>
+<p>This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org/version/3/0/">Contributor Covenant, version 3.0</a>.</p>


### PR DESCRIPTION
Hello! A quick change to deal with issue #89 , I've taken the [current CoC](https://hanamirb.org/community/#code-of-conduct) and put the HTML into the Conduct page. From what I could see this was updated in line with the 3.0 announcement recently.  