### PR TITLE
POC: Search improvements

### DIFF
--- a/app/assets/js/views/docsearch/docsearch.ts
+++ b/app/assets/js/views/docsearch/docsearch.ts
@@ -14,6 +14,12 @@ export const docsearchViewFn: ViewFn<Props> = (container: HTMLElement, { appId, 
     searchParameters: {
       facetFilters: ["version:latest"],
     },
+    transformItems(items) {
+      return items.map((item) => ({
+        ...item,
+        url: item.url.replace(/^https?:\/\/[^\/]+/, ''),
+      }));
+    },
   });
 
   return {

--- a/app/assets/js/views/docsearch/docsearch.ts
+++ b/app/assets/js/views/docsearch/docsearch.ts
@@ -17,7 +17,7 @@ export const docsearchViewFn: ViewFn<Props> = (container: HTMLElement, { appId, 
     transformItems(items) {
       return items.map((item) => ({
         ...item,
-        url: item.url.replace(/^https?:\/\/[^\/]+/, ''),
+        url: item.url.replace(/^https?:\/\/[^\/]+/, ""),
       }));
     },
   });

--- a/app/templates/blog/show.html.erb
+++ b/app/templates/blog/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, post.title %>
 
-<article>
+<article class="search-content">
   <header>
     <h2><%= post.title %></h2>
 

--- a/app/templates/docs/show.html.erb
+++ b/app/templates/docs/show.html.erb
@@ -8,12 +8,12 @@
 <% end %>
 
 <header>
-  <h1><%= doc.title %></h1>
+  <h1 class="lvl1"><%= doc.title %></h1>
 </header>
 
 <div data-testid="doc-versions">
   <% other_versions.each do |version| %>
-    <a href="<%= doc.url_path(version) %>"><%= version %></a>
+    <a class="lvl2" href="<%= doc.url_path(version) %>"><%= version %></a>
   <% end %>
 </div>
 
@@ -27,7 +27,7 @@
 
 <hr>
 
-<main>
+<main class="search-content">
   <header>
     <h1><%= page.title %></h1>
   </header>

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -18,9 +18,7 @@
         lg:overflow-y-auto lg:max-h-[calc(100vh-var(--hn-nav-height))]
       "
     >
-      <h2 class="font-black mb-4 text-rose-500 lvl1">
-          <%= org_name(org) %>
-      </h2>
+      <h2 class="font-black mb-4 text-rose-500 lvl1"><%= org_name(org) %></h2>
 
       <h2 class="font-mono text-xs tracking-wider pt-1 mb-3 uppercase">
         All guides

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -18,6 +18,10 @@
         lg:overflow-y-auto lg:max-h-[calc(100vh-var(--hn-nav-height))]
       "
     >
+      <h2 class="font-black mb-4 text-rose-500 lvl1">
+          <%= org_name(org) %>
+      </h2>
+
       <h2 class="font-mono text-xs tracking-wider pt-1 mb-3 uppercase">
         All guides
       </h2>

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -53,7 +53,7 @@
     </div>
   </aside>
 
-  <section class="lg:col-span-13 lg:grid lg:grid-cols-13 md:col-span-4">
+  <section class="lg:col-span-13 lg:grid lg:grid-cols-13 md:col-span-4 search-content">
     <aside class="lg:col-span-3 lg:order-2">
       <div
         class="

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -26,7 +26,7 @@
 
       <div data-testid="org-guide-versions">
         <% other_versions.each do |version| %>
-          <a href="<%= "/guides/#{org}/#{version}" %>"><%= version %></a>
+          <a class="lvl2" href="<%= "/guides/#{org}/#{version}" %>"><%= version %></a>
         <% end %>
       </div>
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,1 @@
-Sitemap: http://hanamirb.org/sitemap.xml.gz
+Sitemap: https://hanakai.org/sitemap.xml.gz


### PR DESCRIPTION
I'm experimenting with a few things for the search, trying to make sense of Algolia's docs and how to achieve our aims with it. What I'm trying:

- Experimenting with reformatting the search result URL with `transformItems`, to remove the domain in the item URL. The goal here is for the search to work in local dev envs
- Set an explicit class on the main content following [the advice here](https://docsearch.algolia.com/docs/required-configuration#use-the-right-classes-as-recordprops). I plan to set this in the crawler configuration as the `content` selector. This will hopefully ensure we capture the breadcrumbs and the H1s in the index, as previously I was using the `.content` selector for this.
- Add the organisation name (ie: ROM, Dry, Hanami) to the top of the sidebar on the Guides page. Set an explicit `lvl1` class on this, so we can set it as the lvl1 property in the index. I want to see what result this gives us when we reindex.
- Add an explicit `lvl2` class to the doc/guide version, so that we can set this as the lvl2 property in the index. I note that we already have the version in a meta tag, which I understand we can use for filtering/faceting, but I also want to try showing the version number for a guide/doc in the search results dialog. 

eg: for a Guide page like this:
https://hanakai.org/guides/hanami/v2.2/database/configuration

If I search for "DATABASE_URL", it would be cool to see in the search results that text in the context of that page and some indication that the page lives under Guides > Hanami > 2.2 > Database