### PR TITLE
Rejig search-related classes

### DIFF
--- a/app/templates/docs/show.html.erb
+++ b/app/templates/docs/show.html.erb
@@ -13,7 +13,7 @@
 
 <div data-testid="doc-versions">
   <% other_versions.each do |version| %>
-    <a class="lvl2" href="<%= doc.url_path(version) %>"><%= version %></a>
+    <a href="<%= doc.url_path(version) %>"><%= version %></a>
   <% end %>
 </div>
 

--- a/app/templates/docs/show.html.erb
+++ b/app/templates/docs/show.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <header>
-  <h1 class="lvl1"><%= doc.title %></h1>
+  <h1 class="search-lvl1"><%= doc.title %></h1>
 </header>
 
 <div data-testid="doc-versions">

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -51,7 +51,7 @@
     </div>
   </aside>
 
-  <section class="lg:col-span-13 lg:grid lg:grid-cols-13 md:col-span-4 search-content">
+  <section class="lg:col-span-13 lg:grid lg:grid-cols-13 md:col-span-4">
     <aside class="lg:col-span-3 lg:order-2">
       <div
         class="
@@ -91,7 +91,7 @@
         </div>
       </div>
     </aside>
-    <div class="lg:col-span-10 lg:pr-8 lg:mt-8 lg:mb-14">
+    <div class="lg:col-span-10 lg:pr-8 lg:mt-8 lg:mb-14 search-content">
       <header class="pt-1 mb-3">
         <h1 class="font-mono text-xs text-rose-500 tracking-wider uppercase">
           <a href="<%= guide.url_path %>"><%= guide.title %></a>

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -18,7 +18,7 @@
         lg:overflow-y-auto lg:max-h-[calc(100vh-var(--hn-nav-height))]
       "
     >
-      <h2 class="font-black mb-4 text-rose-500 lvl1"><%= org_name(org) %></h2>
+      <h2 class="font-black mb-4 text-rose-500 search-lvl1"><%= org_name(org) %></h2>
 
       <h2 class="font-mono text-xs tracking-wider pt-1 mb-3 uppercase">
         All guides

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -26,7 +26,7 @@
 
       <div data-testid="org-guide-versions">
         <% other_versions.each do |version| %>
-          <a class="lvl2" href="<%= "/guides/#{org}/#{version}" %>"><%= version %></a>
+          <a href="<%= "/guides/#{org}/#{version}" %>"><%= version %></a>
         <% end %>
       </div>
 


### PR DESCRIPTION
More futzing with search
- Moves `search-content` class to the main content div on Guides
- Updates the naming convention for the classes
- Removes the lvl2 class for the moment while we try to get the search results more reliable