### PR TITLE
Rejig search classes: take 2

### DIFF
--- a/app/templates/blog/show.html.erb
+++ b/app/templates/blog/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, post.title %>
 
-<article class="search-content">
+<article>
   <header>
     <h2><%= post.title %></h2>
 
@@ -9,5 +9,5 @@
     <p data-testid="author"><%= post.author %></p>
   </header>
 
-  <div class="content"><%= post.content_html %></div>
+  <div class="content search-content"><%= post.content_html %></div>
 </article>

--- a/app/templates/blog/show.html.erb
+++ b/app/templates/blog/show.html.erb
@@ -2,7 +2,7 @@
 
 <article>
   <header>
-    <h2><%= post.title %></h2>
+    <h2 class="search-lvl2"><%= post.title %></h2>
 
     <p data-testid="date"><%= post.published_date %></p>
 

--- a/app/templates/docs/show.html.erb
+++ b/app/templates/docs/show.html.erb
@@ -27,10 +27,10 @@
 
 <hr>
 
-<main class="search-content">
+<main>
   <header>
     <h1><%= page.title %></h1>
   </header>
 
-  <div class="content"><%= page.content_html %></div>
+  <div class="content search-content"><%= page.content_html %></div>
 </main>

--- a/app/templates/docs/show.html.erb
+++ b/app/templates/docs/show.html.erb
@@ -29,7 +29,7 @@
 
 <main>
   <header>
-    <h1 class="search-lvl2""><%= page.title %></h1>
+    <h1 class="search-lvl2"><%= page.title %></h1>
   </header>
 
   <div class="content search-content"><%= page.content_html %></div>

--- a/app/templates/docs/show.html.erb
+++ b/app/templates/docs/show.html.erb
@@ -29,7 +29,7 @@
 
 <main>
   <header>
-    <h1><%= page.title %></h1>
+    <h1 class="search-lvl2""><%= page.title %></h1>
   </header>
 
   <div class="content search-content"><%= page.content_html %></div>

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -95,13 +95,13 @@
     </aside>
     <div class="lg:col-span-10 lg:pr-8 lg:mt-8 lg:mb-14">
       <header class="pt-1 mb-3">
-        <h1 class="font-mono text-xs text-rose-500 tracking-wider uppercase">
+        <h1 class="font-mono text-xs text-rose-500 tracking-wider uppercase search-lvl2">
           <a href="<%= guide.url_path %>"><%= guide.title %></a>
         </h1>
       </header>
 
       <header>
-        <h1 class="text-4xl font-black mb-4 text-rose-500">
+        <h1 class="text-4xl font-black mb-4 text-rose-500 search-lvl3">
           <%= page.title %>
         </h1>
       </header>

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -95,7 +95,12 @@
     </aside>
     <div class="lg:col-span-10 lg:pr-8 lg:mt-8 lg:mb-14">
       <header class="pt-1 mb-3">
-        <h1 class="font-mono text-xs text-rose-500 tracking-wider uppercase search-lvl2">
+        <h1
+          class="
+            font-mono text-xs text-rose-500 tracking-wider uppercase
+            search-lvl2
+          "
+        >
           <a href="<%= guide.url_path %>"><%= guide.title %></a>
         </h1>
       </header>

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -93,7 +93,7 @@
         </div>
       </div>
     </aside>
-    <div class="lg:col-span-10 lg:pr-8 lg:mt-8 lg:mb-14 search-content">
+    <div class="lg:col-span-10 lg:pr-8 lg:mt-8 lg:mb-14">
       <header class="pt-1 mb-3">
         <h1 class="font-mono text-xs text-rose-500 tracking-wider uppercase">
           <a href="<%= guide.url_path %>"><%= guide.title %></a>
@@ -106,7 +106,7 @@
         </h1>
       </header>
 
-      <div class="content"><%= page.content_html %></div>
+      <div class="content search-content"><%= page.content_html %></div>
     </div>
   </section>
 </div>


### PR DESCRIPTION
Once again, more futzing with the search-related classes to hopefully improve the quality of the hierarchy in the search index:

- Moves the search-content classes down to the content div
- Adds some specific lvl2 and lvl3 classes so we can target specific headings