### PR TITLE
Expose `theme` to layout and use to switch theme as you navigate between orgs

### DIFF
--- a/app/templates/layouts/app.html.erb
+++ b/app/templates/layouts/app.html.erb
@@ -2,10 +2,7 @@
 
 <html
   lang="en"
-  class="
-    scroll-pt-[calc(var(--hk-nav-height)+var(--spacing)*7)]
-    theme-hanami-light
-  "
+  class="scroll-pt-[calc(var(--hk-nav-height)+var(--spacing)*7)] theme-<%= theme %>-light"
 >
   <head>
     <meta charset="UTF-8">

--- a/app/view.rb
+++ b/app/view.rb
@@ -25,5 +25,33 @@ module Site
         NavItem.new(label: "Sponsor", url: "/sponsor", selected: path == "/sponsor", children: [])
       ]
     end
+
+    expose :theme, layout: true, decorate: false do |context:, org: nil, slug: nil|
+      orgs = %w[hanami dry rom]
+
+      detected = nil
+
+      # If org was provided explicitly (e.g. from guides actions), trust it
+      if org && orgs.include?(org)
+        detected = org
+      end
+
+      path = context.request.path
+
+      # Infer org from /docs/:slug pattern
+      if detected.nil?
+        slug ||= path[/\A\/docs\/([^\/]+)/, 1]
+        if slug
+          if orgs.include?(slug)
+            detected = slug
+          else
+            prefix = slug.split(/[-_]/).first
+            detected = prefix if orgs.include?(prefix)
+          end
+        end
+      end
+
+      detected || "hanakai"
+    end
   end
 end


### PR DESCRIPTION
Fairly naive implementation for now, but does bring up the question of whether we should add `org` as a more explicit param to the URLs under `/docs`. What do you reckon, @timriley?