### PR TITLE
Codify Netlify build step and set Ruby/Node versions explicitly

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build]
+  command = "bin/static-build"
+  publish = "build"
+
+  [build.environment]
+  # Netlify doesn’t recognise .tool-versions. This should be kept in sync with that file.
+  RUBY_VERSION = "3.4.3"
+  NODE_VERSION = "22.15.0"


### PR DESCRIPTION
Our Netlify build is failing, I _think_ due to a mismatch between our specified Ruby version (in `.tool-versions` and the default Ruby version that is on Netlify’s base images). Unclear exactly why it’s manifested now, since [we haven’t touched that file in 5 months](https://github.com/hanakai-rb/site/blame/main/.tool-versions).

This PR does two things:

- Sets the Ruby and Node versions on Netlify to the same versions we specify in `.tool-versions`. Bit annoying to have that spread out, but it’ll be fairly obvious when it breaks.
- Outlines the build step in code, rather than Netlify in-app config.