### PR TITLE
Handle trailing slashes with rack-rewrite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "hanami-view", "~> 2.2"
 gem "dry-types", "~> 1.7"
 gem "dry-operation"
 gem "puma"
+gem "rack-rewrite"
 gem "rake"
 gem "sqlite3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.13)
+    rack-rewrite (1.5.1)
     rack-test (2.2.0)
       rack (>= 1.3)
     rainbow (3.1.1)
@@ -406,6 +407,7 @@ DEPENDENCIES
   html-pipeline
   parklife
   puma
+  rack-rewrite
   rack-test
   rake
   sitemap_generator
@@ -413,4 +415,4 @@ DEPENDENCIES
   standard
 
 BUNDLED WITH
-   2.5.23
+   2.7.2

--- a/config/app.rb
+++ b/config/app.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 require "hanami"
+require "rack/rewrite"
 
 module Site
   class App < Hanami::App
     require "site/content_file_middleware"
     config.middleware.use ContentFileMiddleware
+    config.middleware.use Rack::Rewrite do
+      r302 %r{^/(.+)/$}, "/$1"
+    end
 
     config.actions.content_security_policy[:script_src] += " 'unsafe-inline'"
     config.actions.content_security_policy[:connect_src] += " https://*.algolia.net https://*.algolianet.com https://*.algolia.io"
@@ -23,9 +27,7 @@ module Site
         self
       end
 
-      private
-
-      def load_content
+      private def load_content
         # Start the db provider, which will auto-migrate the tables (see config/providers/db.rb)
         start :db
 


### PR DESCRIPTION
Right now if we visit a guide page like /guides/hanami/v2.2/getting-started with a trailing slash at the end then Puma will 404. This isn't currently a problem in production due to the CDN doing the same thing, but if we ever deploy this elsewhere it might become a problem and it's certainly unnecessarily annoying in development mode.

Extracted from #120 and #122 