### PR TITLE
Restore passing tests

### DIFF
--- a/app/templates/doc_pages/_pages_nav_desktop.html.erb
+++ b/app/templates/doc_pages/_pages_nav_desktop.html.erb
@@ -14,6 +14,7 @@
       <%= render "svgs/#{org}_logo", width: 24, height: 24 %>
       <%= render "doc_pages/version_select",
               id: "version-select",
+              testid: "version-select",
               version: version,
               other_versions: other_versions,
               path_prefix: path_prefix,

--- a/app/templates/doc_pages/_pages_nav_mobile.html.erb
+++ b/app/templates/doc_pages/_pages_nav_mobile.html.erb
@@ -83,6 +83,7 @@
             <div class="flex gap-2 order-2 sticky top-3 self-start items-center">
               <%= render "doc_pages/version_select",
                         id: "version-select",
+                        testid: nil,
                         version: version,
                         other_versions: other_versions,
                         path_prefix: path_prefix,

--- a/app/templates/doc_pages/_version_select.html.erb
+++ b/app/templates/doc_pages/_version_select.html.erb
@@ -1,6 +1,6 @@
 <%# TODO: Handle when no other versions %>
 
-<div class="relative font-mono text-xs" data-testid="<%= id %>">
+<div class="relative font-mono text-xs" data-testid="<%= testid %>">
   <button
     class="
       inline-flex gap-1 items-center bg-primary rounded-lg px-2 py-1 text-primary-reversed

--- a/app/templates/docs/show.html.erb
+++ b/app/templates/docs/show.html.erb
@@ -11,7 +11,7 @@
 
     <%= render_with_slots "doc_pages/pages_nav_mobile", org:, version:, other_versions:, path_prefix: "/docs/#{doc.slug}" do |pages_nav_mobile| %>
       <%= pages_nav_mobile.slot :nav do %>
-        <%= render "doc_pages/pages_nav", pages: doc.pages.nested, depth: 0, testid: 'pages-nav', current_page_url: page.url_path %>
+        <%= render "doc_pages/pages_nav", pages: doc.pages.nested, depth: 0, testid: nil, current_page_url: page.url_path %>
       <% end %>
 
       <% if page.nested_headings.length > 0 %>
@@ -19,7 +19,7 @@
           <nav
             data-defo-target-current="<%= { activeClassNames: ["font-bold", "b-primary"] }.to_json %>"
           >
-            <%= render "doc_pages/toc_desktop_headings", headings: page.nested_headings, testid: "headings-toc", depth: 0 %>
+            <%= render "doc_pages/toc_desktop_headings", headings: page.nested_headings, testid: nil, depth: 0 %>
           </nav>
         <% end %>
       <% end %>

--- a/app/templates/guides/index.html.erb
+++ b/app/templates/guides/index.html.erb
@@ -114,6 +114,7 @@
           <div data-testid="hanami-versions">
             <%= render "doc_pages/version_select",
                       id: "hanami-version-select",
+                      testid: nil,
                       version: versions.fetch("hanami").first,
                       other_versions: versions.fetch("hanami"),
                       path_prefix: "/guides/hanami",
@@ -153,6 +154,7 @@
           <div data-testid="dry-versions">
             <%= render "doc_pages/version_select",
                       id: "dry-version-select",
+                      testid: nil,
                       version: versions.fetch("dry").first,
                       other_versions: versions.fetch("dry"),
                       path_prefix: "/guides/dry",
@@ -192,6 +194,7 @@
           <div data-testid="rom-versions">
             <%= render "doc_pages/version_select",
                       id: "rom-version-select",
+                      testid: nil,
                       version: versions.fetch("rom").first,
                       other_versions: versions.fetch("rom"),
                       path_prefix: "/guides/rom",

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -25,7 +25,7 @@
 
     <%= render_with_slots "doc_pages/pages_nav_mobile", org:, version:, other_versions:, path_prefix: "/guides/#{org}" do |pages_nav_mobile| %>
       <%= pages_nav_mobile.slot :nav do %>
-        <ol data-testid="guides-list">
+        <ol>
           <% org_guides.each do |guide_for_nav| %>
             <li class="mb-6">
               <div
@@ -47,7 +47,7 @@
           <nav
             data-defo-target-current="<%= { activeClassNames: ["font-bold", "b-primary"] }.to_json %>"
           >
-            <%= render "doc_pages/toc_desktop_headings", headings: page.nested_headings, testid: "headings-toc", depth: 0 %>
+            <%= render "doc_pages/toc_desktop_headings", headings: page.nested_headings, testid: nil, depth: 0 %>
           </nav>
         <% end %>
       <% end %>


### PR DESCRIPTION
Some of the recent nav changes upset our feature specs due to there being more testid elements on the page than our tests expected.

In this change I mostly set the testid to nil for the mobile versions of our markup, meaning our tests just operate against what we render on the desktop displays.

cc @makenosound in case I've broken anything.