### PR TITLE
Do not swallow 500 and 30x responses when crawling

### DIFF
--- a/Parkfile
+++ b/Parkfile
@@ -28,22 +28,6 @@ end
 # Patch Parklife crawler to handle errors gracefully
 require "parklife/crawler"
 
-module AllowErrorAndRedirect
-  def process_route(...)
-    super
-  rescue Parklife::HTTPError => e
-    # Handle 500 errors and redirects by warning and continuing
-    if e.message.include?("500 response") || e.message =~ /30[0-8] response/
-      $stderr.puts "Warning: #{e.message} - skipping"
-      false
-    else
-      raise
-    end
-  end
-end
-
-Parklife::Crawler.prepend AllowErrorAndRedirect
-
 Parklife.application.configure do |config|
   config.app = Site::App
 

--- a/content/docs/dry/dry-container/v0.11/_index.md
+++ b/content/docs/dry/dry-container/v0.11/_index.md
@@ -7,7 +7,7 @@ pages:
 
 ### Introduction
 
-`dry-container` is a simple, thread-safe container, intended to be one half of a dependency injection system, possibly in combination with [dry-auto_inject](//doc/dry-auto_inject/).
+`dry-container` is a simple, thread-safe container, intended to be one half of a dependency injection system, possibly in combination with [dry-auto_inject](//doc/dry-auto_inject).
 
 At its most basic, dependency injection is a simple technique that makes it possible to implement patterns or principles of code design that rely on object composition, such as the [SOLID principles](https://en.wikipedia.org/wiki/SOLID). By being passed its dependencies instead of instantiating them itself, your code can be written to depend on abstractions, with implementations that can vary independently, potentially at runtime or for specific use-cases, such as injecting a double instead of an expensive web service call when running tests. A container offers two main improvements to basic dependency injection: it takes the work out of manually instantiating and composing trees of dependencies, and it makes it trivial to swap out one implementation of a dependency for another.
 

--- a/content/docs/dry/dry-monads/v1.8/_index.md
+++ b/content/docs/dry/dry-monads/v1.8/_index.md
@@ -175,4 +175,4 @@ If you're interested in functional programming in general, consider learning oth
 
 ## Credits
 
-dry-monads is inspired by Josep M. Bach’s [Kleisli](https://github.com/txus/kleisli) gem and its usage by [dry-transaction](/gems/dry-transaction/) and [dry-types](/gems/dry-types/).
+dry-monads is inspired by Josep M. Bach’s [Kleisli](https://github.com/txus/kleisli) gem and its usage by [dry-transaction](/gems/dry-transaction) and [dry-types](/gems/dry-types).

--- a/content/docs/dry/dry-operation/v1.0/_index.md
+++ b/content/docs/dry/dry-operation/v1.0/_index.md
@@ -109,4 +109,4 @@ end
 
 This pattern matching allows you to handle different types of failures in a clear and explicit manner.
 
-You can read more about dry-monads' `Result` usage in the [dry-monads documentation](//doc/dry-monads/result/).
+You can read more about dry-monads' `Result` usage in the [dry-monads documentation](//doc/dry-monads/result).

--- a/content/posts/2017/2017-01-30-announcing-dry-view-a-functional-view-rendering-system-for-ruby.md
+++ b/content/posts/2017/2017-01-30-announcing-dry-view-a-functional-view-rendering-system-for-ruby.md
@@ -6,7 +6,7 @@ author: Tim Riley
 
 Say hello to **dry-view**, the newest member of the dry-rb family!
 
-We’re pleased to announce the release of dry-view 0.2.1 and share its [brand new documentation](/gems/dry-view/).
+We’re pleased to announce the release of dry-view 0.2.1 and share its [brand new documentation](/gems/dry-view).
 
 Keen followers of dry-rb will note that dry-view has been around for a little while now, living on quietly as an extension of solnic’s original rodakase experiment.
 

--- a/content/posts/2017/2017-08-11-announcing-hanami-110beta1.md
+++ b/content/posts/2017/2017-08-11-announcing-hanami-110beta1.md
@@ -144,7 +144,7 @@ Entities by default infer their schema (set of attributes) from the correspondin
 For instance, if `people` table has `id`, `name`, `created_at`, and `updated_at` columns, then `Person` will have the same attributes.
 
 It may happen that you're not happy with this inferring, and you want to customize the schema.
-We call it this feature ["manual schema"](/guides/1.0/models/entities/#manual-schema).
+We call it this feature ["manual schema"](/guides/1.0/models/entities#manual-schema).
 
 It was introduced with Hanami 1.0 and this is how it works:
 
@@ -207,7 +207,7 @@ Person.new(id: "1", name: "Luca")
 
 ### Selectively boot apps
 
-With Hanami you can build your project by following the [Monolith-First](/guides/1.0/architecture/overview/#monolith-first) principle.
+With Hanami you can build your project by following the [Monolith-First](/guides/1.0/architecture/overview#monolith-first) principle.
 You add more and more code to the project, but growing it organically, by using several Hanami apps.
 
 There are cases of real world products using a **dozen of Hanami apps in the same project** (eg `web` for the frontend, `admin` for the administration, etc..)

--- a/content/posts/2017/2017-10-16-announcing-hanami-110-rc1.md
+++ b/content/posts/2017/2017-10-16-announcing-hanami-110-rc1.md
@@ -61,7 +61,7 @@ In the example above, `StoryRepository` can reference the author of a comment as
 Entities by default have a set of attributes (schema) which is the representation of a relation.
 For instance `User` will have all the columns of `users` database table.
 
-You can bypass this feature to build customize the attributes via [_custom schema_](http://hanamirb.org/guides/1.0/models/entities/#custom-schema).
+You can bypass this feature to build customize the attributes via [_custom schema_](http://hanamirb.org/guides/1.0/models/entities#custom-schema).
 
 Now you can use entities to be an attribute in a _custom schema_ via `Types::Entity()`.
 

--- a/content/posts/2017/2017-10-25-annoucing-hanami-110.md
+++ b/content/posts/2017/2017-10-25-annoucing-hanami-110.md
@@ -213,7 +213,7 @@ Person.new(id: "1", name: "Luca")
 
 ### Selectively boot apps
 
-With Hanami you can build your project by following the [Monolith-First](/guides/1.1/architecture/overview/#monolith-first) principle.
+With Hanami you can build your project by following the [Monolith-First](/guides/1.1/architecture/overview#monolith-first) principle.
 You add more and more code to the project, but growing it organically, by using several Hanami apps.
 
 There are cases of real world products using a **dozen of Hanami apps in the same project** (eg `web` for the frontend, `admin` for the administration, etc..)

--- a/content/posts/2019/2019-02-12-dry-view-0-6-0-an-introductory-talk-and-plans-for-1-0.md
+++ b/content/posts/2019/2019-02-12-dry-view-0-6-0-an-introductory-talk-and-plans-for-1-0.md
@@ -4,7 +4,7 @@ date: 2019-02-12 12:00 UTC
 author: Tim Riley
 ---
 
-Last month we released [dry-view](/gems/dry-view/) 0.6.0, a very special release that made huge strides towards the system's overall completeness. With 0.6.0, dry-view should now offer _everything you need_ to write better organized views in Ruby.
+Last month we released [dry-view](/gems/dry-view) 0.6.0, a very special release that made huge strides towards the system's overall completeness. With 0.6.0, dry-view should now offer _everything you need_ to write better organized views in Ruby.
 
 From here, our goal is to take dry-view to version 1.0. So please give this release a try! Your feedback at this point will help ensure 1.0 is as polished as possible.
 
@@ -12,7 +12,7 @@ If you're new to dry-view, or would like to see its new features presented in co
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/VGWt1OLFzdU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-I'd also invite you to take another look at the [dry-view documentation](/gems/dry-view/). This has been brought up to date and covers all the new features.
+I'd also invite you to take another look at the [dry-view documentation](/gems/dry-view). This has been brought up to date and covers all the new features.
 
 And as for what’s changed with this release, here are the highlights:
 

--- a/content/posts/2020/2020-03-11-dry-schema-and-dry-validation-1-5-0-released.md
+++ b/content/posts/2020/2020-03-11-dry-schema-and-dry-validation-1-5-0-released.md
@@ -36,7 +36,7 @@ UserSchema.(name: "Jane", role: { id: "admin", expires_on: "oops" }).errors.to_h
 # {role: {expires_on: ["must be a date"]}}
 ```
 
-[Refer to the documentation](/gems/dry-schema/1.5/advanced/composing-schemas/) for more information.
+[Refer to the documentation](/gems/dry-schema/1.5/advanced/composing-schemas) for more information.
 
 ## Errors about unexpected keys
 


### PR DESCRIPTION
I’d prefer our crawler be strict and force us to fix local content, rather than allow bad pages to accumulate (and potentially break the live site).

Remove the module extending Parklife to ignore 500 and 30x errors, and address the sources of those errors across a few content pages.

A future job will be to handle the 404s, too! Added https://github.com/hanakai-rb/site/issues/136 to remind us of this.