### PR TITLE
Fix search result persistence

### DIFF
--- a/app/assets/js/views/pagefind-search.ts
+++ b/app/assets/js/views/pagefind-search.ts
@@ -196,7 +196,6 @@ export const pagefindSearchViewFn: ViewFn<Props> = (
       activateElements.forEach((el) => el.removeEventListener("click", onActivateClick));
       deactivateElements.forEach((el) => el.removeEventListener("click", onDeactivateClick));
       window.removeEventListener("keydown", onKeyDown, { capture: true });
-      window.removeEventListener("unload", saveTermCache);
       pagefindInstance.destroy();
       focusTrap.deactivate();
     },


### PR DESCRIPTION
We already have an implementation that _should_ be repopulating the search as we navigate but it mostly didn’t work. I _think_ this is  because our listener was being torn down (by us) before it fired.

I’ve also added an implementation to make filters part of the cache.