### PR TITLE
Don't escape heading text in TOC

### DIFF
--- a/app/content/page.rb
+++ b/app/content/page.rb
@@ -13,7 +13,7 @@ module Site
       attribute :content, Types::Strict::String
 
       class Heading < Site::Struct
-        attribute :text, Types::Strict::String
+        attribute :text, Types::Strict::String.constructor(->(str) { str.html_safe })
         attribute :href, Types::Strict::String
         attribute :level, Types::Strict::Integer
       end


### PR DESCRIPTION
<img width="913" height="382" alt="Screenshot_20251117_113713" src="https://github.com/user-attachments/assets/eaed987b-2be2-42af-b92b-6673f08c0155" />

Fixes #168 