### PR TITLE
Specify language versions in all relevant places

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,13 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: "3.4.3"
           bundler-cache: true
 
       - uses: actions/setup-node@v4
         name: Setup Node
         with:
-          node-version: 22
+          node-version: "22.15.0"
           cache: npm
       - run: npm ci
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://gem.coop"
 
+ruby "3.4.3"
+
 gem "hanami", "~> 2.3.0"
 gem "hanami-assets", "~> 2.3.0"
 gem "hanami-controller", "~> 2.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,5 +455,8 @@ DEPENDENCIES
   sqlite3
   standard
 
+RUBY VERSION
+   ruby 3.4.3p32
+
 BUNDLED WITH
    2.7.2

--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ For the site’s initial launch, we’re tracking our work [in this project boar
 
 ## Setup
 
-Make sure you have Ruby and Node.js installed (see [.tool-versions](.tool-versions) for expected versions), then run:
+Make sure you have Ruby and Node.js installed. See [.tool-versions](.tool-versions) for expected versions. Feel free to use your own preferred version manager.
 
-```
-bin/setup
+Then, to set up the site:
+
+```shell
+$ bin/setup
 ```
 
 To see common commands for operating the site:
 
-```
-bin/setup help
+```shell
+$ bin/setup help
 ```

--- a/bin/setup
+++ b/bin/setup
@@ -24,10 +24,10 @@ def help
       bin/setup
         # Set up the app
 
-      bundle exec hanami dev
+      bin/hanami dev
         # Run the app locally
 
-      bundle exec rspec
+      bin/rspec
         # Run tests
 
       bin/setup help

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,9 @@
         "prettier": "^3.6.2",
         "typescript": "^5.8.3",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": "22.15.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "site",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "22.15.0"
+  },
   "scripts": {
     "lint:all": "npm run lint:types && npm run lint:format && npm run lint:herb",
     "lint:herb": "npx --no-install herb-lint",


### PR DESCRIPTION
Specify the exact Ruby/Node.js versions to use not only in `.tool-versions`, but also in `Gemfile` and `package.json`, while also specifying the full and matching version to use in CI.

While here, update the README to specify that we’re not being prescriptive with regard to version manager tooling.