### PR TITLE
Makes headings for guide-level nav clearer

### DIFF
--- a/app/templates/doc_pages/_breadcrumbs.html.erb
+++ b/app/templates/doc_pages/_breadcrumbs.html.erb
@@ -27,7 +27,7 @@
     <% end %>
   </ol>
 
-  <div class="flex gap-2 order-2 sticky top-3 self-start items-center -mt-0.5">
+  <div class="flex gap-2 order-2 sticky top-3 self-start items-center">
     <% if version %>
       <%= render "doc_pages/version_select",
                             id: "version-select-mobile",
@@ -38,6 +38,6 @@
                             anchor: "right" %>
     <% end %>
 
-    <%= render "svgs/#{org}_logo", width: 28, height: 28 %>
+    <%= render "svgs/#{org}_logo", width: 28, height: 28, class_name: "lg:hidden" %>
   </div>
 </nav>

--- a/app/templates/doc_pages/_pages_nav_desktop.html.erb
+++ b/app/templates/doc_pages/_pages_nav_desktop.html.erb
@@ -7,6 +7,14 @@
   data-defo-ensure-active-nav-link-visible="<%= { id: "desktop-pages-nav" }.to_json %>"
 >
   <div class="sticky top-0">
+    <div class="bg-white flex gap-2 pb-2 items-center mt-2">
+      <p class="font-semibold text-primary text-lg leading-tight">
+        <%= org.capitalize %>
+      </p>
+
+      <%= render "svgs/#{org}_logo", width: 24, height: 24 %>
+    </div>
+
     <div class="bg-linear-to-b from-white to-transparent h-4 pointer-events-none"></div>
   </div>
 

--- a/app/templates/doc_pages/_pages_nav_mobile.html.erb
+++ b/app/templates/doc_pages/_pages_nav_mobile.html.erb
@@ -23,7 +23,7 @@
           font-mono text-xs font-semibold text-primary tracking-wider uppercase
         "
       >
-        Menu
+        Learn <%= org.capitalize %>
         <%= render "svgs/icons/caret_down", width: 16, height: 16, class_name: "fill-current -mt-0.5 [.active_&]:hidden" %>
         
         <%= render "svgs/icons/x", width: 16, height: 16, class_name: "fill-current -mt-0.5 hidden [.active_&]:block" %>

--- a/app/view.rb
+++ b/app/view.rb
@@ -18,7 +18,7 @@ module Site
     expose :header_nav_items, layout: true do |context:|
       path = context.request.path
       [
-        NavItem.new(label: "Guides", url: "/guides", selected: path.start_with?("/guides"), children: []),
+        NavItem.new(label: "Learn", url: "/guides", selected: path.start_with?("/guides"), children: []),
         NavItem.new(label: "Blog", url: "/blog", selected: path.start_with?("/blog"), children: []),
         NavItem.new(label: "Community", url: "/community", selected: path.start_with?("/community"), children: []),
         NavItem.new(label: "Conduct", url: "/conduct", selected: path == "/conduct", children: []),
@@ -29,7 +29,7 @@ module Site
     expose :footer_nav_items, layout: true do |context:|
       path = context.request.path
       [
-        NavItem.new(label: "Guides", url: "/guides", selected: path.start_with?("/guides"), children: [
+        NavItem.new(label: "Learn", url: "/guides", selected: path.start_with?("/guides"), children: [
           NavItem.new(label: "Hanami", url: "/guides#hanami", selected: false, children: []),
           NavItem.new(label: "Dry", url: "/guides#dry", selected: false, children: []),
           NavItem.new(label: "Rom", url: "/guides#rom", selected: false, children: [])

--- a/app/views/guides/show.rb
+++ b/app/views/guides/show.rb
@@ -98,8 +98,7 @@ module Site
         Breadcrumb = Data.define(:label, :url, :root)
         expose :breadcrumbs do |guide, org:|
           [
-            Breadcrumb.new(label: "Guides", url: "/guides", root: true),
-            Breadcrumb.new(label: org.capitalize, url: "/guides##{org}", root: false),
+            Breadcrumb.new(label: org.capitalize, url: "/guides##{org}", root: true),
             Breadcrumb.new(label: guide.title, url: guide.url_path, root: false)
           ]
         end


### PR DESCRIPTION
Resolves [#208](https://github.com/hanakai-rb/site/issues/208)

"Learn Hanami" on mobile, "Hanami" on desktop with the nav changed to "Learn"
