### PR TITLE
Show selected self-versioned guide in guides list

### DIFF
--- a/app/views/guides/show.rb
+++ b/app/views/guides/show.rb
@@ -32,9 +32,15 @@ module Site
           guide.pages[path]
         end
 
-        expose :org_guides do |org:, org_version: nil, guide_version: nil|
+        expose :org_guides do |guide, org:, org_version: nil, guide_version: nil|
           if org_version
             guide_repo.all_for(org:, version: org_version)
+          elsif guide_version
+            guide_repo.latest_for(org:).tap { |guides|
+              # Ensure the currently selected guide (which may have an older version) is the one
+              # that appears in the guides list.
+              guides[guide.position] = guide
+            }
           else
             guide_repo.latest_for(org:)
           end


### PR DESCRIPTION
When you go to an older version of a self-versioned guide, show that version in particular in the LHS guides list, so that it can be shown as the current guide.

To test this, visit http://localhost:2300/learn/dry/dry-types/v1.8, then select the (older) v1.7 version, and note that it still shows as the active version in the LHS guides list. Also note that links to the _other_ pages in the Dry Types guide also point to the (currently selected) v1.7 version.

Fixes #213