### PR TITLE
Update ERD colors to match Hanami theme

### DIFF
--- a/content/guides/hanami/v2.3/database/many-to-many.svg
+++ b/content/guides/hanami/v2.3/database/many-to-many.svg
@@ -6,7 +6,7 @@
     <path d="M4,139L14,139Q24,139,24,129L24,32Q24,22,14,22L4,22L4,22L14,22Q24,22,24,32L24,129Q24,139,14,139L4,139ZM14,135L14,143M4,18L14,22L4,26" fill="none" stroke="#9B9CA4" stroke-width="1"/>
   </svg>
   <svg x="0" y="3">
-    <rect x="0" y="0" width="207.8000030517578" height="32" fill="#685D9F"/>
+    <rect x="0" y="0" width="207.8000030517578" height="32" fill="oklch(0.7193 0.18 10.67)"/>
     <text x="10" y="19.25" style="font-family: sans-serif; font-size: 13px; font-weight: bold; fill: rgb(255, 255, 255);">books</text>
   </svg>
   <svg x="0" y="35">
@@ -46,7 +46,7 @@
     <text x="170.66666984558105" y="19.25" style="font-family: sans-serif; font-size: 13px; fill: rgb(153, 153, 153);">date</text>
   </svg>
   <svg x="268" y="0">
-    <rect x="0" y="0" width="169.6999969482422" height="32" fill="#685D9F"/>
+    <rect x="0" y="0" width="169.6999969482422" height="32" fill="oklch(0.7193 0.18 10.67)"/>
     <text x="10" y="19.25" style="font-family: sans-serif; font-size: 13px; font-weight: bold; fill: rgb(255, 255, 255);">authorships</text>
   </svg>
   <svg x="268" y="32">
@@ -71,7 +71,7 @@
     <text x="143.83333015441895" y="19.25" style="font-family: sans-serif; font-size: 13px; fill: rgb(153, 153, 153);">int</text>
   </svg>
   <svg x="258.0999984741211" y="181">
-    <rect x="0" y="0" width="179.5999984741211" height="32" fill="#685D9F"/>
+    <rect x="0" y="0" width="179.5999984741211" height="32" fill="oklch(0.7193 0.18 10.67)"/>
     <text x="10" y="19.25" style="font-family: sans-serif; font-size: 13px; font-weight: bold; fill: rgb(255, 255, 255);">authors</text>
   </svg>
   <svg x="258.0999984741211" y="213">

--- a/content/guides/hanami/v2.3/database/many-to-one.svg
+++ b/content/guides/hanami/v2.3/database/many-to-one.svg
@@ -3,7 +3,7 @@
     <path d="M4,54L24,54L41.5,54Q51.5,54,51.5,44L51.5,32Q51.5,22,61.5,22L79,22L99,22L99,22L79,22L61.5,22Q51.5,22,51.5,32L51.5,44Q51.5,54,41.5,54L24,54L4,54ZM4,50L14,54L4,58M89,18L89,26" fill="none" stroke="#9B9CA4" stroke-width="1"/>
   </svg>
   <svg x="0" y="0">
-    <rect x="0" y="0" width="207.8000030517578" height="32" fill="#685D9F"/>
+    <rect x="0" y="0" width="207.8000030517578" height="32" fill="oklch(0.7193 0.18 10.67)"/>
     <text x="10" y="19.25" style="font-family: sans-serif; font-size: 13px; font-weight: bold; fill: rgb(255, 255, 255);">books</text>
   </svg>
   <svg x="0" y="32">
@@ -43,7 +43,7 @@
     <text x="170.66666984558105" y="19.25" style="font-family: sans-serif; font-size: 13px; fill: rgb(153, 153, 153);">date</text>
   </svg>
   <svg x="302.8000030517578" y="0">
-    <rect x="0" y="0" width="137.96666717529297" height="32" fill="#685D9F"/>
+    <rect x="0" y="0" width="137.96666717529297" height="32" fill="oklch(0.7193 0.18 10.67)"/>
     <text x="10" y="19.25" style="font-family: sans-serif; font-size: 13px; font-weight: bold; fill: rgb(255, 255, 255);">publishers</text>
   </svg>
   <svg x="302.8000030517578" y="32">

--- a/content/guides/hanami/v2.3/database/one-to-many.svg
+++ b/content/guides/hanami/v2.3/database/one-to-many.svg
@@ -3,7 +3,7 @@
     <path d="M4,54L24,54L41.5,54Q51.5,54,51.5,44L51.5,32Q51.5,22,61.5,22L79,22L99,22L99,22L79,22L61.5,22Q51.5,22,51.5,32L51.5,44Q51.5,54,41.5,54L24,54L4,54ZM4,50L14,54L4,58M89,18L89,26" fill="none" stroke="#9B9CA4" stroke-width="1"/>
   </svg>
   <svg x="0" y="0">
-    <rect x="0" y="0" width="207.8000030517578" height="32" fill="#685D9F"/>
+    <rect x="0" y="0" width="207.8000030517578" height="32" fill="oklch(0.7193 0.18 10.67)"/>
     <text x="10" y="19.25" style="font-family: sans-serif; font-size: 13px; font-weight: bold; fill: rgb(255, 255, 255);">books</text>
   </svg>
   <svg x="0" y="32">
@@ -43,7 +43,7 @@
     <text x="170.66666984558105" y="19.25" style="font-family: sans-serif; font-size: 13px; fill: rgb(153, 153, 153);">date</text>
   </svg>
   <svg x="302.8000030517578" y="0">
-    <rect x="0" y="0" width="137.96666717529297" height="32" fill="#685D9F"/>
+    <rect x="0" y="0" width="137.96666717529297" height="32" fill="oklch(0.7193 0.18 10.67)"/>
     <text x="10" y="19.25" style="font-family: sans-serif; font-size: 13px; font-weight: bold; fill: rgb(255, 255, 255);">publishers</text>
   </svg>
   <svg x="302.8000030517578" y="32">


### PR DESCRIPTION
Embedding SVG as images is much simpler than what I was going to do, so all we need now is to update the colors to match the new theme.

The one downside to this approach is that we can't use the CSS variables, so I hard-coded them.

Closes #221 