### PR TITLE
Remove “Guides” from “Learn” pages titles

### DIFF
--- a/app/templates/guides/index.html.erb
+++ b/app/templates/guides/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Guides" %>
+<% content_for :title, "Learn" %>
 
 <%= render_with_slots "doc_pages/main" do |main| %>
   <%= main.slot :navigation do %>

--- a/app/templates/guides/org_index.html.erb
+++ b/app/templates/guides/org_index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{org_name(org_slug)} #{version} Guides" %>
+<% content_for :title, "Learn #{org_name(org_slug)} #{version}" %>
 
 <%= render_with_slots "doc_pages/main" do |main| %>
   <%= main.slot :navigation do %>

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, "#{guide.title} / #{page.title} &middot; #{org_name(org)} #{version} Guides" %>
+<%= content_for :title, "#{guide.title} / #{page.title} &middot; #{org_name(org)} #{version}" %>
 
 <%= render_with_slots "doc_pages/main" do |main| %>
   <%# Navigation %>


### PR DESCRIPTION
“Guides” is the old name.