### PR TITLE
Order Dry guides alphabetically, show deprecated

### DIFF
--- a/app/content/loaders/guides.rb
+++ b/app/content/loaders/guides.rb
@@ -7,7 +7,11 @@ module Site
     module Loaders
       # Loads guides from content/guides/ into the database.
       class Guides
-        GuideData = Data.define(:org, :slug, :title, :version, :version_scope)
+        GuideData = Data.define(:org, :slug, :title, :version, :version_scope, :deprecated) do
+          def initialize(deprecated: false, **attrs)
+            super
+          end
+        end
 
         GUIDES_YML = "guides.yml"
         GUIDES_KEY = :guides

--- a/app/relations/guides.rb
+++ b/app/relations/guides.rb
@@ -10,6 +10,7 @@ module Site
         attribute :position, Types::Nominal::Integer
         attribute :version, Types::Nominal::String.optional
         attribute :version_scope, Types::Nominal::String
+        attribute :deprecated, Types::Nominal::Bool
       end
     end
   end

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -15,6 +15,10 @@
                 "
               >
                 <%= guide_for_nav.title %>
+
+                <% if guide_for_nav.deprecated %>
+                  (Deprecated)
+                <% end %>
               </div>
 
               <%= render "doc_pages/pages_nav", pages: guide_for_nav.pages.nested, depth: 0, testid: 'pages-nav', current_page_url: page.url_path %>
@@ -36,6 +40,10 @@
                 "
               >
                 <%= guide_for_nav.title %>
+
+                <% if guide_for_nav.deprecated %>
+                  (Deprecated)
+                <% end %>
               </div>
 
               <%= render "doc_pages/pages_nav", pages: guide_for_nav.pages.nested, depth: 0, testid: 'pages-nav', current_page_url: page.url_path %>

--- a/content/guides/dry/guides.yml
+++ b/content/guides/dry/guides.yml
@@ -3,18 +3,8 @@ guides:
     title: Getting started
   - slug: dry-auto_inject
     title: Dry Auto Inject
-  - slug: dry-equalizer
-    title: Dry Equalizer
   - slug: dry-cli
     title: Dry CLI
-  - slug: dry-container
-    title: Dry Container
-  - slug: dry-operation
-    title: Dry Operation
-  - slug: dry-types
-    title: Dry Types
-  - slug: dry-view
-    title: Dry View
   - slug: dry-configurable
     title: Dry Configurable
   - slug: dry-core
@@ -23,6 +13,8 @@ guides:
     title: Dry Effects
   - slug: dry-events
     title: Dry Events
+  - slug: dry-equalizer
+    title: Dry Equalizer
   - slug: dry-files
     title: Dry Files
   - slug: dry-inflector
@@ -35,6 +27,8 @@ guides:
     title: Dry Monads
   - slug: dry-monitor
     title: Dry Monitor
+  - slug: dry-operation
+    title: Dry Operation
   - slug: dry-rails
     title: Dry Rails
   - slug: dry-schema
@@ -43,5 +37,14 @@ guides:
     title: Dry Struct
   - slug: dry-system
     title: Dry System
+  - slug: dry-types
+    title: Dry Types
+  - slug: dry-container
+    title: Dry Container
+    deprecated: true
   - slug: dry-transaction
     title: Dry Transaction
+    deprecated: true
+  - slug: dry-view
+    title: Dry View
+    deprecated: true


### PR DESCRIPTION
Alphabetical ordering makes it easiest to find other guides, I think. "Getting started" remains at the top of the list, of course. In this area we'll add a more themed/categorised set of links to all the guides.

Put deprecated guides at the end of the list, and mark them as "deprecated". @makenosound — this needs some design love.

<img width="325" height="820" alt="Screenshot 2025-11-29 at 10 12 32 pm" src="https://github.com/user-attachments/assets/2c2c4af2-0925-4a19-9af9-1305bbbcc879" />
