### PR TITLE
Fix guides order inside Hanami

### DIFF
--- a/app/content/loaders/guides.rb
+++ b/app/content/loaders/guides.rb
@@ -22,7 +22,7 @@ module Site
         def call(root: GUIDES_PATH)
           root.glob("*").select(&:directory?)
             .flat_map { |org_path| load_guides_for_org(org_path) }
-            .group_by { |guide| [guide.org, guide.slug] }
+            .group_by { |guide| (guide.version_scope == "org") ? [guide.org, guide.version, guide.slug] : [guide.org, guide.slug] }
             .each_with_index do |(org_slug, guide_versions), position|
               guide_versions.each do |guide|
                 relation.insert(**guide.to_h, position:)


### PR DESCRIPTION
Inside Hanami, guides positions are assigned "globally", which results in "Upgrade notes" going before "Database" etc., because in docs for 2.1 the are defined after "Assets" - and this get carried over to 2.3 docs. The fix introduces grouping by version too, but only if version score is `org`, otherwise it breaks docs for Dry.

TBH I'm not sure I 100% understand why this works :see_no_evil: 