### PR TITLE
Remove mentions of dry-container from non-deprecated guides

### DIFF
--- a/content/guides/dry/dry-auto_inject/v1.1/_index.md
+++ b/content/guides/dry/dry-auto_inject/v1.1/_index.md
@@ -8,7 +8,7 @@ pages:
 
 dry-auto_inject provides low-impact dependency injection and resolution support for your classes.
 
-It’s designed to work with a container that holds your application’s dependencies. It works well with [dry-container](//org_guide/dry/dry-container), but supports any container that responds to the `#[]` interface.
+It’s designed to work with a container that holds your application’s dependencies. It is already integrated with [dry-system's containers](/learn/dry/dry-system/v1.2/container), but supports any container that responds to the `#[]` interface.
 
 ### Why use dry-auto_inject?
 
@@ -19,16 +19,15 @@ By using a container and dry-auto_inject, this process becomes easy. You don’t
 ### Usage example
 
 ```ruby
-# Set up a container (using dry-container here)
+# Set up a custom container
 class MyContainer
-  extend Dry::Container::Mixin
-
-  register "users_repository" do
-    UsersRepository.new
-  end
-
-  register "operations.create_user" do
-    CreateUser.new
+  def self.[](name)
+    case name
+    when "users_repository"
+      UsersRepository.new
+    when "operations.create_user"
+      CreateUser.new
+    end
   end
 end
 

--- a/content/guides/dry/dry-auto_inject/v1.1/basic-usage.md
+++ b/content/guides/dry/dry-auto_inject/v1.1/basic-usage.md
@@ -4,9 +4,7 @@ title: Basic usage
 
 ### Requirements
 
-You need only one thing before you can use dry-auto_inject: a container to hold your application’s dependencies. These are commonly known as “inversion of control” containers.
-
-A [dry-container](//org_guide/dry/dry-container) will work well, but the only requirement is that the container responds to the `#[]` interface. For example, `my_container["users_repository"]` should return the “users_repository” object registered with the container.
+You need only one thing before you can use dry-auto_inject: a container to hold your application’s dependencies. These are commonly known as “inversion of control” containers. In DRY ecosystem, the default way to work with container is to use [dry-system](/learn/dry/dry-system/v1.2/container), where auto-inject is already integrated. However, you can use any object that the container responds to the `#[]` interface. For example, `my_container["users_repository"]` should return the “users_repository” object registered with the container.
 
 ### Creating an injector
 

--- a/content/guides/dry/dry-effects/v0.5/effects/resolve.md
+++ b/content/guides/dry/dry-effects/v0.5/effects/resolve.md
@@ -66,9 +66,9 @@ use ProviderMiddleware, user_repo: UserRepo.new
 run Application.new
 ```
 
-### Compatibility with `dry-container` and `dry-system`
+### Compatibility with `dry-system`
 
-Any object that responds to `.key?` and `.[]` can be used for providing dependencies. Thus, the default Resolve provider is compatible with `dry-container` and `dry-system` out of the box.
+Any object that responds to `.key?` and `.[]` can be used for providing dependencies. Thus, the default Resolve provider is compatible with `dry-system` out of the box.
 
 ```ruby
 def call(env)

--- a/content/guides/dry/dry-system/v1.2/_index.md
+++ b/content/guides/dry/dry-system/v1.2/_index.md
@@ -11,7 +11,7 @@ pages:
   - test-mode
 ---
 
-Object dependency management system based on [dry-container](//org_guide/dry/dry-container) and [dry-auto_inject](//org_guide/dry/dry-auto_inject) allowing you to configure reusable components in any environment, set up their load-paths, require needed files and instantiate objects automatically with the ability to have them injected as dependencies.
+Object dependency management system based on containers and [dry-auto_inject](//org_guide/dry/dry-auto_inject) allowing you to configure reusable components in any environment, set up their load-paths, require needed files and instantiate objects automatically with the ability to have them injected as dependencies.
 
 This library relies on very basic mechanisms provided by Ruby, specifically `require` and managing `$LOAD_PATH`. It doesn't use magic like automatic const resolution, it's pretty much the opposite and forces you to be explicit about dependencies in your applications.
 

--- a/content/guides/rom/v5.0/getting-started/rails-setup.md
+++ b/content/guides/rom/v5.0/getting-started/rails-setup.md
@@ -77,7 +77,7 @@ end
 > [!WARNING]
 > Accessing the global container directly is considered as a bad practice. The recommended way is to use a DI mechanism to inject specific ROM components as dependencies into your objects.
 >
-> For example you can use [dry-container](https://github.com/dryrb/dry-container) and [dry-auto_inject](https://github.com/dryrb/dry-auto_inject) to define your own application container and specify dependencies there to have them automatically injected.
+> For example you can use [dry-system's containers](/learn/dry/dry-system/v1.2/container) and [dry-auto_inject](https://github.com/dryrb/dry-auto_inject) to define your own application container and specify dependencies there to have them automatically injected.
 >
 > See [rom-rails-skeleton](https://github.com/solnic/rom-rails-skeleton) for an example of such setup.
 


### PR DESCRIPTION
dry-container has been deprecated and we should not point user to use them. Where applicable, the mentions of dry-container are replaced by dry-system's containers.

I left mentions in other deprecated gems, such as dry-transaction.