### PR TITLE
Add banners to guides

### DIFF
--- a/app/content/loaders/guides.rb
+++ b/app/content/loaders/guides.rb
@@ -7,8 +7,8 @@ module Site
     module Loaders
       # Loads guides from content/guides/ into the database.
       class Guides
-        GuideData = Data.define(:org, :slug, :title, :version, :version_scope, :deprecated) do
-          def initialize(deprecated: false, **attrs)
+        GuideData = Data.define(:org, :slug, :title, :version, :version_scope, :deprecated, :banner, :banner_type) do
+          def initialize(deprecated: false, banner: nil, banner_type: "note", **attrs)
             super
           end
         end

--- a/app/relations/guides.rb
+++ b/app/relations/guides.rb
@@ -11,6 +11,8 @@ module Site
         attribute :version, Types::Nominal::String.optional
         attribute :version_scope, Types::Nominal::String
         attribute :deprecated, Types::Nominal::Bool
+        attribute :banner, Types::Nominal::String.optional
+        attribute :banner_type, Types::Nominal::String.optional
       end
     end
   end

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -79,6 +79,14 @@
       <%= render "doc_pages/breadcrumbs", breadcrumbs:, org:, version:, versions:, path_prefix: %>
     </div>
 
+    <% if guide.banner %>
+      <div class="content">
+        <div class="markdown-alert markdown-alert-<%= guide.banner_type %>">
+          <%= guide.banner_content %>
+        </div>
+      </div>
+    <% end %>
+
     <header
       data-pagefind-filter="project[data-project]"
       data-pagefind-meta="project[data-project]"

--- a/app/views/parts/guide.rb
+++ b/app/views/parts/guide.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Site
+  module Views
+    module Parts
+      class Guide < Views::Part
+        def banner_content
+          Commonmarker.to_html(banner).html_safe
+        end
+      end
+    end
+  end
+end

--- a/content/guides/dry/dry-rails/v0.7/_index.md
+++ b/content/guides/dry/dry-rails/v0.7/_index.md
@@ -4,9 +4,6 @@ title: Introduction
 name: dry-rails
 ---
 
-> [!NOTE]
-> Before dry-rails hits 1.0.0 it should be considered as beta software. Various usage patterns should emerge as more people try it out, so please do so and provide feedback!
-
 `dry-rails` is the official dry-rb railtie for Ruby on Rails framework. It provides an application container using `dry-system` with additional features:
 
 - `:safe_params` - a small controller extension that adds the ability to define schemas for controller actions

--- a/content/guides/dry/dry-view/v0.8/_index.md
+++ b/content/guides/dry/dry-view/v0.8/_index.md
@@ -11,8 +11,6 @@ pages:
   - testing
 ---
 
-**Development of dry-view has ceased. Please switch to [hanami-view](https://github.com/hanami/view) for a compatible replacement.**
-
 dry-view is a complete, standalone view rendering system that gives you everything you need to write well-factored view code.
 
 Use dry-view if:

--- a/content/guides/dry/guides.yml
+++ b/content/guides/dry/guides.yml
@@ -31,6 +31,7 @@ guides:
     title: Dry Operation
   - slug: dry-rails
     title: Dry Rails
+    banner: "Before dry-rails hits 1.0.0 it should be considered as beta software. Various usage patterns should emerge as more people try it out, so please do so and provide feedback!"
   - slug: dry-schema
     title: Dry Schema
   - slug: dry-struct
@@ -42,9 +43,15 @@ guides:
   - slug: dry-container
     title: Dry Container
     deprecated: true
+    banner: "dry-container is deprecated. Check out [dry-system's container](/learn/dry/dry-system/v1.2/container) instead."
+    banner_type: warning
   - slug: dry-transaction
     title: Dry Transaction
     deprecated: true
+    banner: "dry-transaction is deprecated and has been superseded by [dry-operation](/learn/dry/dry-operation/v1.2/overview)."
+    banner_type: warning
   - slug: dry-view
     title: Dry View
     deprecated: true
+    banner: "Development of dry-view has ceased. Please switch to [hanami-view](/learn/hanami/view/v1.2/overview) for a compatible replacement."
+    banner_type: warning


### PR DESCRIPTION
My take at #231, a bit different from what's described in the issue, because it adds a message to every page of the guides. I think this is important, in case someone arrives to the guide from a search engine.

<img width="1695" height="901" alt="Screenshot_20260107_211648" src="https://github.com/user-attachments/assets/07d5621b-8b7d-4447-90e9-8840b627bac4" />

It can also be used to denote different things than deprecations, as shown with dry-rails message.

Notes:
* I put the banner above the guide title, to make it visually feel like it's not a part of page content
* I reused styles for markdown alerts, but they were only available as children of `.content`, so I had to wrap it in a content div. But we might not want to use markdown alerts styling here directly.
* If we reuse, we might want to have `banner_title` as well.
* We should probably figure out the cohesive naming convention for the gems. It's sometimes "dry-view" and sometimes "Dry View".

(#243 but from a correct branch, so that Netlify preview builds)