### PR TITLE
Fix org-versioned guide positioning

### DIFF
--- a/app/content/loaders/guides.rb
+++ b/app/content/loaders/guides.rb
@@ -7,13 +7,9 @@ module Site
     module Loaders
       # Loads guides from content/guides/ into the database.
       class Guides
-        GuideData = Data.define(:org, :slug, :title, :version, :version_scope, :deprecated, :banner, :banner_type) do
+        GuideData = Data.define(:org, :slug, :version, :version_scope, :position, :title, :deprecated, :banner, :banner_type) do
           def initialize(deprecated: false, banner: nil, banner_type: "note", **attrs)
             super
-          end
-
-          def grouping_key
-            (version_scope == "org") ? [org, version, slug] : [org, slug]
           end
         end
 
@@ -26,12 +22,7 @@ module Site
         def call(root: GUIDES_PATH)
           root.glob("*").select(&:directory?)
             .flat_map { |org_path| load_guides_for_org(org_path) }
-            .group_by(&:grouping_key)
-            .each_with_index do |(org_slug, guide_versions), position|
-              guide_versions.each do |guide|
-                relation.insert(**guide.to_h, position:)
-              end
-            end
+            .each { |guide| relation.insert(**guide.to_h) }
         end
 
         private
@@ -53,8 +44,8 @@ module Site
             next [] unless guides_yml.file?
 
             version = version_dir.basename.to_s
-            parse_guides_yml(guides_yml).map do |guide_attrs|
-              GuideData.new(org:, version:, version_scope: "org", **guide_attrs)
+            parse_guides_yml(guides_yml).map.with_index do |guide_attrs, position|
+              GuideData.new(org:, version:, version_scope: "org", position:, **guide_attrs)
             end
           end
         end
@@ -63,19 +54,19 @@ module Site
           guides_yml = org_path.join(GUIDES_YML)
           return [] unless guides_yml.file?
 
-          parse_guides_yml(guides_yml).flat_map do |guide_attrs|
+          parse_guides_yml(guides_yml).flat_map.with_index do |guide_attrs, position|
             guide_path = org_path.join(guide_attrs.fetch(SLUG_KEY))
             next [] unless guide_path.directory?
 
             guide_version_dirs = guide_path.glob("v*").select(&:directory?)
 
             if guide_version_dirs.none?
-              next [GuideData.new(org:, version: nil, version_scope: "none", **guide_attrs)]
+              next [GuideData.new(org:, version: nil, version_scope: "none", position:, **guide_attrs)]
             end
 
             guide_version_dirs.map do |version_dir|
               version = version_dir.basename.to_s
-              GuideData.new(org:, version:, version_scope: "self", **guide_attrs)
+              GuideData.new(org:, version:, version_scope: "self", position:, **guide_attrs)
             end
           end
         end


### PR DESCRIPTION
Hey @katafrakt! I took a look at #239 and played around with a few options. 

So the bug (thank you for spotting it!) was that we were positioning org-scoped guides across _all_ versions, rather than _within_ each version. Your PR fixed this, and in my first commit here, I tried to make that grouping clearer by making it a method on the `GuidData` class.

But then in my second commit I got to IMO a better outcome: supplying a position _within_ each scoping at the time of loading the guides in the first place. This way each `GuideData` simply carries an appropriate `position` based on the the piece of data that defines our positioning in the first place: `guides.yml`. And with this change, the top-level loading pipeline becomes way simpler: we just get each guide and insert it straight into the table.

I'll (squash and) merge this now. Thanks so much for getting the ball rolling here!

Closes #239.