### PR TITLE
Add redirects for common legacy URLs

### DIFF
--- a/app/content/generate_redirects.rb
+++ b/app/content/generate_redirects.rb
@@ -8,16 +8,6 @@ module Site
       def call
         redirects = []
 
-        legacy_redirects_file = Hanami.app.root.join("config", "legacy_redirects.txt")
-        if File.exist?(legacy_redirects_file)
-          legacy_content = File.read(legacy_redirects_file)
-          legacy_redirects = legacy_content.lines
-            .map(&:strip)
-            .reject { |line| line.empty? || line.start_with?("#") }
-
-          redirects.concat(legacy_redirects)
-        end
-
         # Redirect version-only URLs to the first guide at that version
         versioned_orgs = DEFAULT_GUIDE_VERSIONS.select { |_, version| version }.keys
         versioned_orgs.each do |org|

--- a/bin/generate-redirects
+++ b/bin/generate-redirects
@@ -9,4 +9,12 @@ require "hanami/prepare"
 
 redirects = Hanami.app["content.generate_redirects"].call
 
+static_redirects_file = Hanami.app.root.join("config", "redirects.txt")
+if File.exist?(static_redirects_file)
+  static_content = File.read(static_redirects_file)
+  static_redirects = static_content.lines
+
+  redirects = redirects + "\n" + static_redirects.join("\n")
+end
+
 File.write(Hanami.app.root.join("build", "_redirects"), redirects)


### PR DESCRIPTION
I crawled the existing sites and found the most common URL patterns and then:
- Added a static redirects.txt file that lists the most common redirects from the legacy sites to the new ones
- Adjusted bin/generate-redirects so that these are appended to the `build/_redirects` file after the dynamic redirects

Fixes #177 