### PR TITLE
Fix incorrect information and typo

### DIFF
--- a/content/guides/hanami/v2.3/app/autoloading.md
+++ b/content/guides/hanami/v2.3/app/autoloading.md
@@ -53,7 +53,7 @@ Assuming an app created via `hanami new bookshelf` (which would have a top-level
 
 None of the above classes or modules need a require statement before use.
 
-It's worth noting that, thanks to Hanami's [component managment system](//page/container-and-components), the components you write in `app/` don't commonly need to reference their collaborators using Ruby constants - they instead use the Deps mixin to access their dependencies.
+It's worth noting that, thanks to Hanami's [component management system](//page/container-and-components), the components you write in `app/` don't commonly need to reference their collaborators using Ruby constants - they instead use the Deps mixin to access their dependencies.
 
 If you are adding a class to the `app/` directory that you want to use an autoloaded Ruby constant to reference, it's very likely that you do not want that class to be registered in your app container. To opt out of registration, use the magic comment `# auto_register: false` or one of the alternative methods discussed in "Opting out of the container" in the [container and components guide](//page/container-and-components).
 

--- a/content/guides/hanami/v2.3/getting-started/building-a-web-app.md
+++ b/content/guides/hanami/v2.3/getting-started/building-a-web-app.md
@@ -36,7 +36,7 @@ module Bookshelf
 end
 ```
 
-Hanami provides an action generator we can use to create this action. Running this command will create the home show action:
+Hanami provides an action generator we can use to create this action. Running this command will create the home index action:
 
 ```shell
 $ bin/hanami generate action home.index --skip-route --skip-tests


### PR DESCRIPTION
This PR ﬁxes the following in the documentation.
1. Incorrect information stating that we are creating a show action when it is an index action in the [building a web app](https://hanakai.org/learn/hanami/v2.3/getting-started/building-a-web-app) page.
2.  A typo in the [autoloading](https://hanakai.org/learn/hanami/v2.3/app/autoloading) page/