### PR TITLE
Allow guides to be marked as unlisted

### DIFF
--- a/app/actions/guides/show.rb
+++ b/app/actions/guides/show.rb
@@ -36,7 +36,7 @@ module Site
           return unless version.nil?
 
           # Look for a versioned copy of this guide. If it exists, we can redirect to the latest.
-          latest_guide = guide_repo.with_latest_version(org: params[:org], slug: params[:slug])
+          latest_guide = guide_repo.with_latest_listed_version(org: params[:org], slug: params[:slug])
           return unless latest_guide
 
           redirect_url = latest_guide.url_path

--- a/app/content/loaders/guides.rb
+++ b/app/content/loaders/guides.rb
@@ -7,14 +7,16 @@ module Site
     module Loaders
       # Loads guides from content/guides/ into the database.
       class Guides
-        GuideData = Data.define(:org, :slug, :version, :version_scope, :position, :title, :description, :deprecated, :banner, :banner_type) do
-          def initialize(deprecated: false, banner: nil, banner_type: "note", description: nil, **attrs)
+        GuideData = Data.define(:org, :slug, :version, :version_scope, :position, :title, :description, :deprecated, :banner, :banner_type, :unlisted) do
+          def initialize(deprecated: false, banner: nil, banner_type: "note", description: nil, unlisted: false, **attrs)
             super
           end
         end
 
         GUIDES_YML = "guides.yml"
+        GUIDE_YML = "guide.yml"
         GUIDES_KEY = :guides
+        UNLISTED_KEY = :unlisted
         SLUG_KEY = :slug
 
         include Deps[relation: "relations.guides"]
@@ -43,9 +45,22 @@ module Site
             guides_yml = version_dir.join(GUIDES_YML)
             next [] unless guides_yml.file?
 
+            org_guides_attrs = read_yaml(guides_yml)
             version = version_dir.basename.to_s
-            parse_guides_yml(guides_yml).map.with_index do |guide_attrs, position|
-              GuideData.new(org:, version:, version_scope: "org", position:, **guide_attrs)
+            unlisted = org_guides_attrs[UNLISTED_KEY] || false
+
+            org_guides_attrs.fetch(GUIDES_KEY).filter_map.with_index do |guide_attrs, position|
+              guide_path = version_dir.join(guide_attrs.fetch(SLUG_KEY))
+              next unless guide_path.directory?
+
+              GuideData.new(
+                org:,
+                version:,
+                version_scope: "org",
+                position:,
+                unlisted:,
+                **guide_attrs
+              )
             end
           end
         end
@@ -54,27 +69,45 @@ module Site
           guides_yml = org_path.join(GUIDES_YML)
           return [] unless guides_yml.file?
 
-          parse_guides_yml(guides_yml).flat_map.with_index do |guide_attrs, position|
+          read_yaml(guides_yml).fetch(GUIDES_KEY).flat_map.with_index do |guide_attrs, position|
             guide_path = org_path.join(guide_attrs.fetch(SLUG_KEY))
             next [] unless guide_path.directory?
 
             guide_version_dirs = guide_path.glob("v*").select(&:directory?)
 
             if guide_version_dirs.none?
-              next [GuideData.new(org:, version: nil, version_scope: "none", position:, **guide_attrs)]
+              next [
+                GuideData.new(
+                  org:,
+                  version: nil,
+                  version_scope: "none",
+                  position:,
+                  **guide_attrs
+                )
+              ]
             end
 
             guide_version_dirs.map do |version_dir|
               version = version_dir.basename.to_s
-              GuideData.new(org:, version:, version_scope: "self", position:, **guide_attrs)
+
+              version_guide_yml = version_dir.join(GUIDE_YML)
+              version_guide_attrs = version_guide_yml.file? ? read_yaml(version_guide_yml) : {}
+              unlisted = version_guide_attrs[UNLISTED_KEY] || false
+
+              GuideData.new(
+                org:,
+                version:,
+                version_scope: "self",
+                position:,
+                unlisted:,
+                **guide_attrs
+              )
             end
           end
         end
 
-        def parse_guides_yml(guides_yml)
-          File.read(guides_yml)
-            .then { YAML.load(it, symbolize_names: true) }
-            .fetch(GUIDES_KEY)
+        def read_yaml(path)
+          File.read(path).then { YAML.load(it, symbolize_names: true) }
         end
       end
     end

--- a/app/relations/guides.rb
+++ b/app/relations/guides.rb
@@ -14,7 +14,10 @@ module Site
         attribute :deprecated, Types::Nominal::Bool
         attribute :banner, Types::Nominal::String.optional
         attribute :banner_type, Types::Nominal::String.optional
+        attribute :unlisted, Types::Nominal::Bool
       end
+
+      def listed = where(unlisted: false)
     end
   end
 end

--- a/app/repos/guide_repo.rb
+++ b/app/repos/guide_repo.rb
@@ -36,16 +36,34 @@ module Site
         (self_versioned + unversioned).sort_by(&:position)
       end
 
-      def with_latest_version(org:, slug:)
-        guides
+      def with_latest_listed_version(org:, slug:)
+        listed_guides
           .where(org:, slug:)
           .where { version.not nil }
           .order { guides[:version].desc }
           .limit(1).one
       end
 
+      def latest_listed_org_version(org:)
+        listed_guides
+          .where(org:, version_scope: "org")
+          .order(guides[:version].desc)
+          .limit(1)
+          .pluck(:version)
+          .first
+      end
+
+      def latest_listed_guide_version(org:, slug:)
+        listed_guides
+          .where(org:, slug:, version_scope: "self")
+          .order(guides[:version].desc)
+          .limit(1)
+          .pluck(:version)
+          .first
+      end
+
       def org_versions(org:)
-        guides
+        listed_guides
           .where(org:, version_scope: "org")
           .group(:version)
           .order(guides[:version].desc)
@@ -53,7 +71,7 @@ module Site
       end
 
       def guide_versions(org:, slug:)
-        guides
+        listed_guides
           .where(org:, slug:, version_scope: "self")
           .group(:version)
           .order(guides[:version].desc)
@@ -73,8 +91,8 @@ module Site
         }
       end
 
-      def versions_by_org
-        guides
+      def listed_versions_by_org
+        listed_guides
           .where(version_scope: "org")
           .group(:org, :version)
           .order(guides[:version].desc)
@@ -99,6 +117,8 @@ module Site
       end
 
       private
+
+      def listed_guides = guides.listed
 
       def next_prev_guide_base_query(guide)
         if guide.version_scope == "org"

--- a/app/templates/doc_pages/_version_warning.html.erb
+++ b/app/templates/doc_pages/_version_warning.html.erb
@@ -1,5 +1,5 @@
-<% latest_version = version_links.keys.first
-  latest_version_url = version_links[latest_version] %>
+<% latest_listed_version_url = version_links[latest_listed_version] %>
+<% is_preview = Gem::Version.new(version.delete_prefix("v")) > Gem::Version.new(latest_listed_version.delete_prefix("v")) %>
 
 <div
   class="
@@ -12,11 +12,26 @@
 
   <div class="flex-1 lg:flex lg:flex-row">
     <p class="lg:flex-1 lg:block inline">
-      You’re viewing documentation for version <%= version %>.
+      <% if is_preview %>
+        You’re viewing a preview of guides for version
+        <%= version %>
+        .
+      <% else %>
+        You’re viewing guides for version
+        <%= version %>
+        .
+      <% end %>
     </p>
 
-    <a class="text-rom-500 dark:text-rom-400" href="<%= latest_version_url %>">
-      View latest ->
+    <a
+      class="text-rom-500 dark:text-rom-400"
+      href="<%= latest_listed_version_url %>"
+    >
+      <% if is_preview %>
+        View latest stable ->
+      <% else %>
+        View latest ->
+      <% end %>
     </a>
   </div>
 </div>

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -72,8 +72,8 @@
   <%# Content %>
   <%= main.slot :content do %>
     <div class="flex flex-col">
-      <% if version != latest_version %>
-        <%= render "doc_pages/version_warning", version:, version_links: %>
+      <% if version != latest_listed_version %>
+        <%= render "doc_pages/version_warning", version:, version_links:, latest_listed_version: %>
       <% end %>
 
       <%= render "doc_pages/breadcrumbs", breadcrumbs:, org:, version:, version_links: %>
@@ -97,7 +97,7 @@
       </h1>
     </header>
 
-    <div class="content" <%= "data-pagefind-body" if version == latest_version %>><%= page.content_html %></div>
+    <div class="content" <%= "data-pagefind-body" if version == latest_listed_version %>><%= page.content_html %></div>
 
     <%= render "doc_pages/next_prev_links",
         prev_item: prev_nav_item ? prev_nav_item : nil,

--- a/app/views/guides/index.rb
+++ b/app/views/guides/index.rb
@@ -11,7 +11,7 @@ module Site
         end
 
         private_expose :versions do
-          guide_repo.versions_by_org
+          guide_repo.listed_versions_by_org
         end
 
         expose :hanami_version_links, decorate: false do |versions|

--- a/app/views/guides/show.rb
+++ b/app/views/guides/show.rb
@@ -48,8 +48,8 @@ module Site
           org_version || guide_version
         end
 
-        expose :latest_version, decorate: false do |versions|
-          versions.max
+        expose :latest_listed_version, decorate: false do |org:, slug:|
+          guide_repo.latest_listed_org_version(org:) || guide_repo.latest_listed_guide_version(org:, slug:)
         end
 
         private_expose :versions, decorate: false do |org:, slug:|
@@ -73,8 +73,10 @@ module Site
         #     # ...
         #     "v2.0" => "/learn/hanami/v2.0/getting-started"
         #   }
-        expose :version_links, decorate: false do |versions, org:, slug:, path:|
-          versions.to_h do |other_version|
+        expose :version_links, decorate: false do |versions, version, org:, slug:, path:|
+          versions_to_show = versions.include?(version) ? versions : [version, *versions]
+
+          versions_to_show.to_h do |other_version|
             other_guide = guide_repo.find_by(org:, version: other_version, slug:)
 
             # This guide exists for the other verison. Link to the same page at that version (if it

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -19,14 +19,14 @@ SitemapGenerator::Sitemap.create do
   # Guides
   add "/learn"
 
-  app["repos.guide_repo"].versions_by_org.each do |org, versions|
+  app["repos.guide_repo"].listed_versions_by_org.each do |org, versions|
     # TODO: Update for self-versioned and versionless guides
     versions.each do |version|
       add "/learn/#{org}/#{version}"
     end
   end
 
-  app["repos.guide_repo"].all.each do |guide|
+  app["repos.guide_repo"].all.reject(&:unlisted).each do |guide|
     add guide.url_path
 
     guide.pages.all.each do |page|

--- a/content/guides/hanami/v3.0/getting-started/_index.md
+++ b/content/guides/hanami/v3.0/getting-started/_index.md
@@ -1,0 +1,5 @@
+---
+title: Overview
+---
+
+Get started for Hanami v3.0.

--- a/content/guides/hanami/v3.0/guides.yml
+++ b/content/guides/hanami/v3.0/guides.yml
@@ -1,0 +1,6 @@
+unlisted: true
+
+guides:
+  - slug: getting-started
+    title: Getting started
+    description: Build your first Hanami app from scratch

--- a/spec/features/guides/index_page_spec.rb
+++ b/spec/features/guides/index_page_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Guides / Index page" do
       end
     end
 
-    expected_versions = guide_repo.versions_by_org
+    expected_versions = guide_repo.listed_versions_by_org
     expected_versions.each do |org, versions|
       within "[data-testid=#{org}-versions]" do
         expect(page).to have_content versions.first


### PR DESCRIPTION
Allow guides to be marked as unlisted. This is useful for when we need to prepare the documentation for a version that is yet to be released.

Unlisted guides can be visited directly, but cannot be navigated to via ordinary UI, such as “Learn” area navigation or the guide version pickers. Unlisted guides are not considered when determining the latest version of a guide. Unlisted guides also do not appear in the sitemap.

A guide may be marked as unlisted by:

- Adding `unlisted: true` to an org-versioned `guides.yml`
- Adding `unlisted: true` to a `guide.yml` inside a version dir for a self-versioned guide

To test this functionality, add the getting started guide for Hanami 3.0. This can be visited at `/learn/hanami/v3.0/getting-started`.