### PR TITLE
Use JS to render kerned project names

### DIFF
--- a/app/assets/js/views/index.ts
+++ b/app/assets/js/views/index.ts
@@ -6,6 +6,7 @@ import { overflowClassViewFn } from "./overflow-class";
 import { isMacViewFn } from "./is-mac";
 import { lazyLoadView } from "~/utils/lazy-load";
 import { mobilePageNavViewFn } from "./mobile-page-nav";
+import { replaceWithTemplateViewFn } from "./replace-with-template";
 import { sizeToVarViewFn } from "./size-to-var";
 import { targetCurrentViewFn } from "./target-current";
 import { tocScrollViewFn } from "./toc-scroll";
@@ -22,6 +23,7 @@ export const views: Views = {
   }),
   mobilePageNav: breakpointFilter(mobilePageNavViewFn),
   overflowClass: overflowClassViewFn,
+  replaceWithTemplate: replaceWithTemplateViewFn,
   sizeToVar: sizeToVarViewFn,
   pagefindSearch: pagefindSearchViewFn,
   targetCurrent: targetCurrentViewFn,

--- a/app/assets/js/views/replace-with-template.test.ts
+++ b/app/assets/js/views/replace-with-template.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, expect, test, describe } from "vitest";
+import defo from "@icelab/defo";
+import { replaceWithTemplateViewFn } from "./replace-with-template";
+
+function render(html: string) {
+  document.body.innerHTML = html;
+  defo({ views: { replaceWithTemplate: replaceWithTemplateViewFn } });
+}
+
+describe("replaceWithTemplateViewFn", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("replaces content with the template's first element", () => {
+    render(`
+      <span id="name" data-defo-replace-with-template>
+        Hanami<template><span class="kerned"><span>H</span><span>i</span></span></template>
+      </span>
+    `);
+
+    const node = document.getElementById("name")!;
+    expect(node.querySelector(".kerned")).not.toBeNull();
+    expect(node.querySelector("template")).toBeNull();
+    expect(node.textContent?.trim()).toBe("Hi");
+  });
+
+  test("does nothing when no template is present", () => {
+    render(`<span id="name" data-defo-replace-with-template>Hanami</span>`);
+
+    const node = document.getElementById("name")!;
+    expect(node.textContent).toBe("Hanami");
+  });
+
+  test("only replaces from a direct-child template", () => {
+    render(`
+      <span id="outer" data-defo-replace-with-template>
+        Outer<template><span class="outer-replacement">replaced</span></template>
+        <span><template>nested</template></span>
+      </span>
+    `);
+
+    const node = document.getElementById("outer")!;
+    expect(node.querySelector(".outer-replacement")).not.toBeNull();
+    expect(node.textContent?.trim()).toBe("replaced");
+  });
+});

--- a/app/assets/js/views/replace-with-template.ts
+++ b/app/assets/js/views/replace-with-template.ts
@@ -1,0 +1,23 @@
+import type { ViewFn } from "@icelab/defo";
+
+/**
+ * replaceWithTemplate
+ *
+ * Replaces the element's content with a clone of its child <template>'s first
+ * element. Useful for progressive enhancement: render a simple, semantic
+ * fallback in the source HTML and swap in a richer version once JS runs.
+ *
+ * @example
+ * <span data-defo-replace-with-template>
+ *   Hanami<template><span class="inline-flex">…kerned spans…</span></template>
+ * </span>
+ */
+export const replaceWithTemplateViewFn: ViewFn = (node: HTMLElement) => {
+  const template = Array.from(node.children).find(
+    (child): child is HTMLTemplateElement => child instanceof HTMLTemplateElement,
+  );
+  const replacement = template?.content.firstElementChild;
+  if (!replacement) return;
+
+  node.replaceChildren(replacement.cloneNode(true));
+};

--- a/app/templates/shared/names/_dry.html.erb
+++ b/app/templates/shared/names/_dry.html.erb
@@ -1,5 +1,9 @@
-<span class="inline-flex tracking-tighter font-extrabold">
-  <span>D</span>
-  <span class="mr-[0.07em]">r</span>
-  <span>y</span>
+<span data-defo-replace-with-template>
+  Dry
+  <template>
+    <span class="inline-flex tracking-tighter font-extrabold">
+      <span class="sr-only">Dry</span>
+      <span aria-hidden="true">D</span><span aria-hidden="true" class="mr-[0.07em]">r</span><span aria-hidden="true">y</span>
+    </span>
+  </template>
 </span>

--- a/app/templates/shared/names/_hanakai.html.erb
+++ b/app/templates/shared/names/_hanakai.html.erb
@@ -1,9 +1,9 @@
-<span class="inline-flex tracking-tighter font-extrabold">
-  <span>H</span>
-  <span>a</span>
-  <span>n</span>
-  <span>a</span>
-  <span>k</span>
-  <span>a</span>
-  <span>i</span>
+<span data-defo-replace-with-template>
+  Hanakai
+  <template>
+    <span class="inline-flex tracking-tighter font-extrabold">
+      <span class="sr-only">Hanakai</span>
+      <span aria-hidden="true">H</span><span aria-hidden="true">a</span><span aria-hidden="true">n</span><span aria-hidden="true">a</span><span aria-hidden="true">k</span><span aria-hidden="true">a</span><span aria-hidden="true">i</span>
+    </span>
+  </template>
 </span>

--- a/app/templates/shared/names/_hanami.html.erb
+++ b/app/templates/shared/names/_hanami.html.erb
@@ -1,8 +1,9 @@
-<span class="inline-flex tracking-tighter font-extrabold">
-  <span>H</span>
-  <span class="-ml-[0.019em]">a</span>
-  <span>n</span>
-  <span class="-ml-[0.01em]">a</span>
-  <span>m</span>
-  <span class="-ml-[0.029em]">i</span>
+<span data-defo-replace-with-template>
+  Hanami
+  <template>
+    <span class="inline-flex tracking-tighter font-extrabold">
+      <span class="sr-only">Hanami</span>
+      <span aria-hidden="true">H</span><span aria-hidden="true" class="-ml-[0.019em]">a</span><span aria-hidden="true">n</span><span aria-hidden="true" class="-ml-[0.01em]">a</span><span aria-hidden="true">m</span><span aria-hidden="true" class="-ml-[0.029em]">i</span>
+    </span>
+  </template>
 </span>

--- a/app/templates/shared/names/_rom.html.erb
+++ b/app/templates/shared/names/_rom.html.erb
@@ -1,5 +1,9 @@
-<span class="inline-flex tracking-tighter font-extrabold">
-  <span>R</span>
-  <span class="-ml-[0.015em]">o</span>
-  <span>m</span>
+<span data-defo-replace-with-template>
+  Rom
+  <template>
+    <span class="inline-flex tracking-tighter font-extrabold">
+      <span class="sr-only">Rom</span>
+      <span aria-hidden="true">R</span><span aria-hidden="true" class="-ml-[0.015em]">o</span><span aria-hidden="true">m</span>
+    </span>
+  </template>
 </span>


### PR DESCRIPTION
- Adds a generic `replaceWithTemplate` defo view that swaps an element's contents for a clone of its child `<template>`'s first element.
- Updates the `Hanami`, `Dry`, `Rom`, and `Hanakai` name partials so the source HTML carries the plain word, with the kerned span markup deferred to a `<template>`.
- The kerned replacement now also includes a visually-hidden `sr-only` label and `aria-hidden="true"` on each visible letter so screen readers announce the word once instead of letter-by-letter.

This means crawlers and no-JS users see the proper word as one continuous string (fixing the "H a n a m i" Google snippet), while users with JS still get the kerned visual.

Fixes #301