### PR TITLE
Fix utilities so scrolling panel overlay shows up

### DIFF
--- a/app/assets/css/scrolling-panel.css
+++ b/app/assets/css/scrolling-panel.css
@@ -18,7 +18,7 @@
   }
 }
 
-.scrolling-panel--with-bottom-overlay {
+@utility scrolling-panel--with-bottom-overlay {
   position: relative;
 
   &::after {
@@ -34,26 +34,5 @@
       var(--hk-color-bg-neutral),
       oklch(from var(--hk-color-bg-neutral) l c h / 0)
     );
-  }
-}
-
-@variant lg {
-  .scrolling-panel--with-bottom-overlay {
-    position: relative;
-
-    &::after {
-      content: "";
-      position: sticky;
-      pointer-events: none;
-      display: block;
-      bottom: 0;
-      width: 100%;
-      height: calc(var(--spacing) * 10);
-      background-image: linear-gradient(
-        to top,
-        var(--hk-color-bg-neutral),
-        oklch(from var(--hk-color-bg-neutral) l c h / 0)
-      );
-    }
   }
 }


### PR DESCRIPTION
`lg:scrolling-panel--with-bottom-overlay` wasn’t working because we weren’t generating the utilities, only changing the base `.scrolling-panel--with-bottom-overlay` at the `lg` size.