### PR TITLE
Ensure `/learn/dry` redirects correctly

### DIFF
--- a/app/content/generate_redirects.rb
+++ b/app/content/generate_redirects.rb
@@ -30,6 +30,9 @@ module Site
           else
             # Redirect self-versioned guides
             guides = guide_repo.latest_for(org:)
+            first_guide = guides.min_by(&:position)
+
+            redirects.push("/learn/#{org}   #{first_guide.url_path}") if first_guide
 
             guides.select(&:self_versioned?).each do |guide|
               redirects


### PR DESCRIPTION
Was missing from the `generate_redirects` config.