### PR TITLE
Add post-filter to convert emoji/shortcodes into logos

### DIFF
--- a/app/assets/css/base.css
+++ b/app/assets/css/base.css
@@ -28,3 +28,8 @@ button {
 .font-mono.text-xs {
   font-size: 0.8rem;
 }
+
+.emoji-logo {
+  display: inline-block;
+  vertical-align: -0.1em;
+}

--- a/app/assets/css/content.css
+++ b/app/assets/css/content.css
@@ -46,6 +46,8 @@
   h4,
   h5 {
     display: flex;
+    align-items: center;
+    line-height: var(--leading-tight);
     gap: calc(var(--spacing));
     a[href^="#"] {
       order: 2;

--- a/app/content/filters/emoji_logo_filter.rb
+++ b/app/content/filters/emoji_logo_filter.rb
@@ -1,0 +1,68 @@
+# auto_register: false
+# frozen_string_literal: true
+
+require "cgi"
+require "erb"
+require "nokogiri"
+
+module Site
+  module Content
+    module Filters
+      # Replaces logo shortcodes in rendered content with inline SVGs:
+      #
+      #   🌸, :hanami:  → Hanami logo
+      #   :hanakai:     → Hanakai logo
+      #   :rom:         → ROM logo
+      #   :dry:         → Dry logo
+      #
+      # Skips text inside `<code>` and `<pre>`, so code samples containing the
+      # shortcodes pass through untouched.
+      class EmojiLogoFilter
+        def self.load_svg(name)
+          path = File.expand_path("../../templates/svgs/_#{name}_logo_simple.html.erb", __dir__)
+          ERB.new(File.read(path))
+            .result_with_hash(
+              class_name: "emoji-logo emoji-logo--#{name} inline",
+              height: "1em",
+              width: "1em"
+            )
+            .gsub(/\s+/, " ")
+            .strip
+        end
+
+        HANAMI_SVG = load_svg("hanami")
+        HANAKAI_SVG = load_svg("hanakai")
+        ROM_SVG = load_svg("rom")
+        DRY_SVG = load_svg("dry")
+
+        REPLACEMENTS = {
+          "🌸" => HANAMI_SVG,
+          ":hanami:" => HANAMI_SVG,
+          ":hanakai:" => HANAKAI_SVG,
+          ":rom:" => ROM_SVG,
+          ":dry:" => DRY_SVG
+        }.freeze
+
+        PATTERN = Regexp.union(REPLACEMENTS.keys)
+        SPLIT_PATTERN = /(#{PATTERN})/
+
+        def call(html)
+          return html unless html.match?(PATTERN)
+
+          doc = Nokogiri::HTML::DocumentFragment.parse(html)
+
+          doc.xpath(".//text()[not(ancestor::code) and not(ancestor::pre)]").each do |node|
+            next unless node.content.match?(PATTERN)
+
+            rebuilt = node.content.split(SPLIT_PATTERN).map { |part|
+              REPLACEMENTS[part] || CGI.escapeHTML(part)
+            }.join
+            node.replace(Nokogiri::HTML::DocumentFragment.parse(rebuilt))
+          end
+
+          doc.to_html
+        end
+      end
+    end
+  end
+end

--- a/app/content/markdown.rb
+++ b/app/content/markdown.rb
@@ -4,6 +4,7 @@
 require "html_pipeline"
 require "html_pipeline/convert_filter/markdown_filter"
 require_relative "pipeline"
+require_relative "filters/emoji_logo_filter"
 require_relative "filters/inline_attribute_list_filter"
 
 module Site
@@ -23,7 +24,10 @@ module Site
           node_filters: [],
           sanitization_config: nil
         ),
-        post_filters: [Filters::InlineAttributeListFilter.new]
+        post_filters: [
+          Filters::EmojiLogoFilter.new,
+          Filters::InlineAttributeListFilter.new
+        ]
       )
       private_constant :Pipeline
 

--- a/app/content/page.rb
+++ b/app/content/page.rb
@@ -4,6 +4,7 @@
 require "html_pipeline"
 require "html_pipeline/convert_filter/markdown_filter"
 require_relative "pipeline"
+require_relative "filters/emoji_logo_filter"
 require_relative "filters/inline_attribute_list_filter"
 
 module Site
@@ -62,7 +63,10 @@ module Site
           # Don't bother sanitizing content, we already trust what's in this repo.
           sanitization_config: nil
         ),
-        post_filters: [Filters::InlineAttributeListFilter.new]
+        post_filters: [
+          Filters::EmojiLogoFilter.new,
+          Filters::InlineAttributeListFilter.new
+        ]
       )
       private_constant :ContentPipeline
 

--- a/app/structs/post.rb
+++ b/app/structs/post.rb
@@ -3,6 +3,7 @@
 require "html_pipeline"
 require "html_pipeline/convert_filter/markdown_filter"
 require_relative "../content/pipeline"
+require_relative "../content/filters/emoji_logo_filter"
 require_relative "../content/filters/inline_attribute_list_filter"
 
 module Site
@@ -62,7 +63,10 @@ module Site
           # Don't bother sanitizing content, we already trust what's in this repo.
           sanitization_config: nil
         ),
-        post_filters: [Content::Filters::InlineAttributeListFilter.new]
+        post_filters: [
+          Content::Filters::EmojiLogoFilter.new,
+          Content::Filters::InlineAttributeListFilter.new
+        ]
       )
       private_constant :ContentPipeline
 

--- a/spec/content/filters/emoji_logo_filter_spec.rb
+++ b/spec/content/filters/emoji_logo_filter_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+RSpec.describe Site::Content::Filters::EmojiLogoFilter do
+  def call(html)
+    described_class.new.call(html)
+  end
+
+  it "replaces 🌸 with the Hanami logo SVG" do
+    output = call("<p>Happy coding! 🌸</p>")
+    expect(output).to include("Happy coding! ")
+    expect(output).to include('class="emoji-logo emoji-logo--hanami inline"')
+    expect(output).not_to include("🌸")
+  end
+
+  it "replaces the :hanami: shortcode with the Hanami logo SVG" do
+    output = call("<p>Welcome to :hanami:.</p>")
+    expect(output).to include('class="emoji-logo emoji-logo--hanami inline"')
+    expect(output).not_to include(":hanami:")
+  end
+
+  it "replaces the :hanakai: shortcode with the Hanakai logo SVG" do
+    output = call("<p>See :hanakai:.</p>")
+    expect(output).to include('class="emoji-logo emoji-logo--hanakai inline"')
+    expect(output).not_to include(":hanakai:")
+  end
+
+  it "replaces the :rom: shortcode with the ROM logo SVG" do
+    output = call("<p>Backed by :rom:.</p>")
+    expect(output).to include('class="emoji-logo emoji-logo--rom inline"')
+    expect(output).not_to include(":rom:")
+  end
+
+  it "replaces the :dry: shortcode with the Dry logo SVG" do
+    output = call("<p>Powered by :dry:.</p>")
+    expect(output).to include('class="emoji-logo emoji-logo--dry inline"')
+    expect(output).not_to include(":dry:")
+  end
+
+  it "replaces a mix of shortcodes and emoji in the same text" do
+    output = call("<p>:hanami: + :rom: + :dry: 🌸</p>")
+    expect(output.scan("<svg").length).to eq(4)
+    expect(output.scan("emoji-logo--hanami").length).to eq(2)
+    expect(output.scan("emoji-logo--rom").length).to eq(1)
+    expect(output.scan("emoji-logo--dry").length).to eq(1)
+  end
+
+  it "replaces repeated 🌸 in the same text node" do
+    output = call("<p>🌸🌸🌸</p>")
+    expect(output.scan("<svg").length).to eq(3)
+    expect(output).not_to include("🌸")
+  end
+
+  it "replaces shortcodes across different elements" do
+    output = call("<h2>:hanami: Heading</h2><p>And 🌸 again.</p>")
+    expect(output.scan("<svg").length).to eq(2)
+  end
+
+  it "leaves shortcodes inside a code block untouched" do
+    output = call("<pre><code>puts \":hanami:\"</code></pre>")
+    expect(output).to include(":hanami:")
+    expect(output).not_to include("<svg")
+  end
+
+  it "leaves shortcodes inside inline code untouched" do
+    output = call("<p>Use <code>:dry:</code> as a shortcode.</p>")
+    expect(output).to include("<code>:dry:</code>")
+    expect(output).not_to include("<svg")
+  end
+
+  it "replaces a shortcode alongside inline code" do
+    output = call("<p>The <code>flag</code> :rom: please.</p>")
+    expect(output).to include("<code>flag</code>")
+    expect(output).to include('class="emoji-logo emoji-logo--rom inline"')
+    expect(output).not_to include(":rom:")
+  end
+
+  it "leaves html without any trigger unchanged" do
+    html = "<p>No flowers here.</p>"
+    expect(call(html)).to eq(html)
+  end
+
+  it "preserves surrounding text including characters that need HTML escaping" do
+    output = call("<p>5 < 10 🌸 yes</p>")
+    expect(output).to include("5 &lt; 10 ")
+    expect(output).to include("<svg")
+  end
+end


### PR DESCRIPTION
Sprig Sans is missing :cherry_blossom: which sucks a bit for us 🥲 And so to avoid getting black flowers this converts the literal emoji into the Hanami logo SVG, and then the shortcodes for each org into their own:

```
🌸
:hanakai:
:hanami:
:rom:
:dry:
```