### PR TITLE
Add dismissible banner with merger announcement

### DIFF
--- a/app/assets/js/views/dismissible-banner.test.ts
+++ b/app/assets/js/views/dismissible-banner.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, expect, test, describe } from "vitest";
+import defo from "@icelab/defo";
+import { dismissibleBannerViewFn } from "./dismissible-banner";
+
+function render(config: Parameters<typeof dismissibleBannerViewFn>[1]) {
+  document.body.innerHTML = `
+    <div id="banner" data-defo-dismissible-banner='${JSON.stringify(config)}'>
+      <a href="/post">Announcement</a>
+      <button type="button">Dismiss</button>
+      <button type="button" data-custom-dismiss>Custom dismiss</button>
+    </div>
+  `;
+  defo({ views: { dismissibleBanner: dismissibleBannerViewFn } });
+}
+
+describe("dismissibleBannerViewFn", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    window.localStorage.clear();
+  });
+
+  test("hides the banner and stores the dismissal on click", () => {
+    render({ id: "hanakai" });
+
+    const banner = document.getElementById("banner")!;
+    const button = banner.querySelector("button")!;
+
+    expect(banner.classList.contains("hidden")).toBe(false);
+    expect(window.localStorage.getItem("hk-banner-dismissed:hanakai")).toBe(null);
+
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(banner.classList.contains("hidden")).toBe(true);
+    expect(window.localStorage.getItem("hk-banner-dismissed:hanakai")).toBe("true");
+  });
+
+  test("scopes the storage key to the provided id", () => {
+    render({ id: "other-banner" });
+
+    const button = document.querySelector("#banner button")!;
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(window.localStorage.getItem("hk-banner-dismissed:other-banner")).toBe("true");
+    expect(window.localStorage.getItem("hk-banner-dismissed:hanakai")).toBe(null);
+  });
+
+  test("uses a custom dismissSelector when provided", () => {
+    render({ id: "hanakai", dismissSelector: "[data-custom-dismiss]" });
+
+    const banner = document.getElementById("banner")!;
+    const defaultButton = banner.querySelector("button")!;
+    const customButton = banner.querySelector("[data-custom-dismiss]")!;
+
+    defaultButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(banner.classList.contains("hidden")).toBe(false);
+    expect(window.localStorage.getItem("hk-banner-dismissed:hanakai")).toBe(null);
+
+    customButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(banner.classList.contains("hidden")).toBe(true);
+    expect(window.localStorage.getItem("hk-banner-dismissed:hanakai")).toBe("true");
+  });
+
+  test("does nothing if no matching dismiss button exists", () => {
+    document.body.innerHTML = `
+      <div id="banner" data-defo-dismissible-banner='${JSON.stringify({ id: "hanakai" })}'>
+        <a href="/post">Announcement</a>
+      </div>
+    `;
+
+    expect(() => {
+      defo({ views: { dismissibleBanner: dismissibleBannerViewFn } });
+    }).not.toThrow();
+
+    const banner = document.getElementById("banner")!;
+    expect(banner.classList.contains("hidden")).toBe(false);
+  });
+});

--- a/app/assets/js/views/dismissible-banner.ts
+++ b/app/assets/js/views/dismissible-banner.ts
@@ -1,0 +1,40 @@
+import type { ViewFn } from "@icelab/defo";
+
+const STORAGE_PREFIX = "hk-banner-dismissed:";
+
+type Props = { id: string; dismissSelector?: string };
+
+/**
+ * dismissibleBanner
+ *
+ * Announcement banner that hides itself when the user clicks a child
+ * dismiss button. Persists the dismissal in localStorage so the banner
+ * stays hidden on return visits. An inline script in the partial handles
+ * the initial hide (FOUC-free) by reading the same key.
+ *
+ * @example
+ * <div data-defo-dismissible-banner='{"id":"hanakai"}'>
+ *   <a href="/post">...</a>
+ *   <button data-dismiss>Dismiss</button>
+ * </div>
+ */
+export const dismissibleBannerViewFn: ViewFn<Props> = (
+  node: HTMLElement,
+  { id, dismissSelector = "button" }: Props,
+) => {
+  const key = STORAGE_PREFIX + id;
+  const dismissButton = node.querySelector<HTMLButtonElement>(dismissSelector);
+
+  const handleClick = (event: Event) => {
+    event.preventDefault();
+    window.localStorage.setItem(key, "true");
+    node.classList.add("hidden");
+  };
+  dismissButton?.addEventListener("click", handleClick);
+
+  return {
+    destroy: () => {
+      dismissButton?.removeEventListener("click", handleClick);
+    },
+  };
+};

--- a/app/assets/js/views/index.ts
+++ b/app/assets/js/views/index.ts
@@ -2,6 +2,7 @@ import type { Views } from "@icelab/defo";
 
 import { breakpointFilter } from "~/utils/breakpoints";
 import { copyCodeViewFn } from "./copy-code";
+import { dismissibleBannerViewFn } from "./dismissible-banner";
 import { ensureActiveNavLinkVisibleViewFn } from "./ensure-active-nav-link-visible";
 import { overflowClassViewFn } from "./overflow-class";
 import { isMacViewFn } from "./is-mac";
@@ -17,6 +18,7 @@ import { pagefindSearchViewFn } from "./pagefind-search";
 
 export const views: Views = {
   copyCode: copyCodeViewFn,
+  dismissibleBanner: dismissibleBannerViewFn,
   ensureActiveNavLinkVisible: ensureActiveNavLinkVisibleViewFn,
   isMac: isMacViewFn,
   foresight: lazyLoadView(async () => {

--- a/app/templates/layouts/header/_base.html.erb
+++ b/app/templates/layouts/header/_base.html.erb
@@ -5,6 +5,8 @@
   "
   data-defo-size-to-var="<%= { blockVarName: "--hk-nav-height" }.to_json %>"
 >
+  <%= render "layouts/header/dismissible_banner" %>
+
   <div
     class="
       bg-neutral text-neutral flex items-center gap-2 lg:gap-4 px-4 lg:px-6

--- a/app/templates/layouts/header/_dismissible_banner.html.erb
+++ b/app/templates/layouts/header/_dismissible_banner.html.erb
@@ -1,0 +1,51 @@
+<%
+  # Adjust ID to trigger banner to be shown anew.
+  banner_id = "hanakai-merger-announcement"
+%>
+
+<div
+  data-defo-dismissible-banner="<%= { id: banner_id }.to_json %>"
+  class="bg-neutral text-primary-reversed px-3 pt-1"
+>
+  <div class="bg-primary rounded-xl relative">
+    <a
+      href="/blog"
+      class="
+        block text-center px-10 py-2.5
+        hover:brightness-95 dark:hover:brightness-110 transition
+      "
+    >
+      <strong class="font-semibold">Hanami</strong>,
+      <strong class="font-semibold">Dry</strong>, and
+      <strong class="font-semibold">Rom</strong> are joining as
+      <strong class="font-semibold">Hanakai</strong>.
+      <span class="underline [text-decoration-skip-ink:none]">Read the announcement</span>
+      <span aria-hidden="true">→</span>
+    </a>
+
+    <button
+      type="button"
+      aria-label="Dismiss announcement"
+      class="
+        absolute right-2 top-1/2 -translate-y-1/2
+        flex items-center justify-center
+        w-7 h-7 rounded-md cursor-pointer
+        hover:bg-black/10 dark:hover:bg-white/10 transition
+      "
+    >
+      <%= render "svgs/icons/x", width: 16, height: 16, class_name: "fill-current" %>
+    </button>
+  </div>
+</div>
+
+<script> <%# herb:disable html-require-script-nonce %>
+  (function () {
+    try {
+      var el = document.currentScript.previousElementSibling;
+      var cfg = JSON.parse(el.getAttribute("data-defo-dismissible-banner"));
+      if (localStorage.getItem("hk-banner-dismissed:" + cfg.id) === "true") {
+        el.classList.add("hidden");
+      }
+    } catch (e) {}
+  })();
+</script>


### PR DESCRIPTION
Stores dismissed state in `localStorage` based on the ID, so we can rotate the ID (and the content obvs) when there are new announcements to be made.