### PR TITLE
Group and label deprecated guides in nav, hide from learn index

### DIFF
--- a/app/templates/guides/_nav_guides.html.erb
+++ b/app/templates/guides/_nav_guides.html.erb
@@ -20,7 +20,7 @@
     <li class="mt-8 mb-4 pt-6 border-t border-neutral-200 dark:border-neutral-700">
       <% deprecated_guides.each do |guide| %>
         <div class="mb-6">
-          <div class="flex items-center gap-2 mb-2">
+          <div class="mb-2">
             <span
               class="
                 font-mono uppercase text-xs font-semibold text-primary

--- a/app/templates/guides/_nav_guides.html.erb
+++ b/app/templates/guides/_nav_guides.html.erb
@@ -1,6 +1,6 @@
 <% active_guides, deprecated_guides = guides.partition { !_1.deprecated } %>
 
-<ol <% if defined?(testid) && testid %> data-testid="<%= testid %>" <% end %>>
+<ol data-testid="<%= testid %>">
   <% active_guides.each do |guide| %>
     <li class="mb-6">
       <div

--- a/app/templates/guides/_nav_guides.html.erb
+++ b/app/templates/guides/_nav_guides.html.erb
@@ -1,0 +1,49 @@
+<% active_guides, deprecated_guides = guides.partition { !_1.deprecated } %>
+
+<ol <% if defined?(testid) && testid %> data-testid="<%= testid %>" <% end %>>
+  <% active_guides.each do |guide| %>
+    <li class="mb-6">
+      <div
+        class="
+          font-mono uppercase text-xs font-semibold text-primary
+          tracking-wide mb-2
+        "
+      >
+        <%= guide.title %>
+      </div>
+
+      <%= render "doc_pages/pages_nav", pages: guide.pages.nested, depth: 0, testid: "pages-nav", current_page_url: current_page_url %>
+    </li>
+  <% end %>
+
+  <% if deprecated_guides.any? %>
+    <li class="mt-8 mb-4 pt-6 border-t border-neutral-200 dark:border-neutral-700">
+      <% deprecated_guides.each do |guide| %>
+        <div class="mb-6">
+          <div class="flex items-center gap-2 mb-2">
+            <span
+              class="
+                font-mono uppercase text-xs font-semibold text-primary
+                tracking-wide
+              "
+            >
+              <%= guide.title %>
+            </span>
+
+            <span
+              class="
+                bg-[oklch(from_var(--hk-color-text-primary)_1_calc(c*0.25)_h)]
+                text-[oklch(from_var(--hk-color-text-primary)_calc(l+0.1)_calc(c*0.8)_h)]
+                text-xs font-bold uppercase px-2 py-1 rounded-xl
+              "
+            >
+              Deprecated
+            </span>
+          </div>
+
+          <%= render "doc_pages/pages_nav", pages: guide.pages.nested, depth: 0, testid: "pages-nav", current_page_url: current_page_url %>
+        </div>
+      <% end %>
+    </li>
+  <% end %>
+</ol>

--- a/app/templates/guides/index.html.erb
+++ b/app/templates/guides/index.html.erb
@@ -44,7 +44,7 @@
                name: "ROM",
                theme: "rom",
                description: "A powerful, flexible persistence toolkit that keeps your domain logic clean.",
-               section_guides: guides.fetch("rom"),
+               section_guides: guides.fetch("rom").reject(&:deprecated),
                version_select: {
                  id: "rom-version-select",
                  testid: nil,

--- a/app/templates/guides/index.html.erb
+++ b/app/templates/guides/index.html.erb
@@ -17,7 +17,7 @@
                name: "Hanami",
                theme: "hanami",
                description: "A complete framework for building apps with structure and clarity.",
-               section_guides: guides.fetch("hanami"),
+               section_guides: guides.fetch("hanami").reject(&:deprecated),
                version_select: {
                  id: "hanami-version-select",
                  testid: nil,
@@ -34,7 +34,7 @@
                name: "Dry",
                theme: "dry",
                description: "Validation, types, functional patterns and more, for robust code in any Ruby app.",
-               section_guides: guides.fetch("dry"),
+               section_guides: guides.fetch("dry").reject(&:deprecated),
                version_select: nil %>
 
     <%= render "svgs/wiggle", class_name: "text-[var(--hk-color-b-primary)] mb-14", height: 14, stroke_width: 2 %>

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -11,51 +11,13 @@
   <%= main.slot :navigation do %>
     <%= render_with_slots "doc_pages/pages_nav_desktop", org: do |pages_nav_desktop| %>
       <%= pages_nav_desktop.slot :nav do %>
-        <ol data-testid="guides-list">
-          <% org_guides.each do |guide_for_nav| %>
-            <li class="mb-6">
-              <div
-                class="
-                  font-mono uppercase text-xs font-semibold text-primary
-                  tracking-wide mb-2
-                "
-              >
-                <%= guide_for_nav.title %>
-
-                <% if guide_for_nav.deprecated %>
-                  (Deprecated)
-                <% end %>
-              </div>
-
-              <%= render "doc_pages/pages_nav", pages: guide_for_nav.pages.nested, depth: 0, testid: 'pages-nav', current_page_url: page.url_path %>
-            </li>
-          <% end %>
-        </ol>
+        <%= render "guides/nav_guides", guides: org_guides, current_page_url: page.url_path, testid: "guides-list" %>
       <% end %>
     <% end %>
 
     <%= render_with_slots "doc_pages/pages_nav_mobile", org: do |pages_nav_mobile| %>
       <%= pages_nav_mobile.slot :nav do %>
-        <ol>
-          <% org_guides.each do |guide_for_nav| %>
-            <li class="mb-6">
-              <div
-                class="
-                  font-mono uppercase text-xs font-semibold text-primary
-                  tracking-wide mb-2
-                "
-              >
-                <%= guide_for_nav.title %>
-
-                <% if guide_for_nav.deprecated %>
-                  (Deprecated)
-                <% end %>
-              </div>
-
-              <%= render "doc_pages/pages_nav", pages: guide_for_nav.pages.nested, depth: 0, testid: 'pages-nav', current_page_url: page.url_path %>
-            </li>
-          <% end %>
-        </ol>
+        <%= render "guides/nav_guides", guides: org_guides, current_page_url: page.url_path, testid: nil %>
       <% end %>
 
       <% if page.nested_headings.length > 0 %>

--- a/content/guides/dry/guides.yml
+++ b/content/guides/dry/guides.yml
@@ -76,17 +76,17 @@ guides:
     title: Dry Container
     deprecated: true
     description: Simple inversion-of-control container
-    banner: "dry-container is deprecated. Check out [`Dry::Core::Container`](/learn/dry/dry-core/v1.1/container) instead."
+    banner: "dry-container is deprecated. Check out [`Dry::Core::Container`](/learn/dry/dry-core/container) instead."
     banner_type: warning
   - slug: dry-transaction
     title: Dry Transaction
     deprecated: true
     description: Business transaction DSL (superseded by dry-operation)
-    banner: "dry-transaction is deprecated and has been superseded by [dry-operation](/learn/dry/dry-operation/v1.1/overview)."
+    banner: "dry-transaction is deprecated and has been superseded by [dry-operation](/learn/dry/dry-operation)."
     banner_type: warning
   - slug: dry-view
     title: Dry View
     deprecated: true
     description: Functional view rendering system
-    banner: "Development of dry-view has ceased. Please switch to [hanami-view](/learn/hanami/view/v1.2/overview) for a compatible replacement."
+    banner: "Development of dry-view has ceased. Please switch to [hanami-view](/learn/hanami/views) for a compatible replacement."
     banner_type: warning


### PR DESCRIPTION
- Extracts the guide nav into a shared `guides/nav_guides` partial and groups deprecated guides below a divider, each tagged with a small `Deprecated` pill.
- Filters deprecated guides out of the `/learn` index entirely so they only surface once a reader is inside the relevant gem's docs.

Fixes https://github.com/hanakai-rb/site/issues/200.