### PR TITLE
Fix markdown issue in dry-auto_inject's "how does it work"

### DIFF
--- a/content/guides/dry/dry-auto_inject/v1.1/how-does-it-work.md
+++ b/content/guides/dry/dry-auto_inject/v1.1/how-does-it-work.md
@@ -2,7 +2,7 @@
 title: How does it work?
 ---
 
-dry-auto*inject enables \_constructor dependency injection* for your objects. It achieves this by defining two methods in the module that you include in your class.
+dry-auto_inject enables constructor dependency injection for your objects. It achieves this by defining two methods in the module that you include in your class.
 
 First, it defines `.new`, which resolves your dependencies from the container, if you haven't otherwise provided them as explicit arguments. It then passes these dependencies as arguments onto `#initialize`, as per Ruby’s usual behaviour.
 


### PR DESCRIPTION
Currently looks like this:

<img width="988" height="222" alt="Screenshot_20260422_175712" src="https://github.com/user-attachments/assets/bd3c8ff9-c4c8-41d4-8660-a70249c448a2" />
