### PR TITLE
Use top-level URLs for project pages

### DIFF
--- a/app/og_images/manifest.rb
+++ b/app/og_images/manifest.rb
@@ -54,7 +54,7 @@ module Site
           data: {title: "AI contribution policy", org: "hanakai"}
         },
         {
-          path: "/projects/hanami",
+          path: "/hanami",
           output: "pages/hanami.png",
           template: "page",
           data: {
@@ -64,7 +64,7 @@ module Site
           }
         },
         {
-          path: "/projects/dry",
+          path: "/dry",
           output: "pages/dry.png",
           template: "page",
           data: {
@@ -74,7 +74,7 @@ module Site
           }
         },
         {
-          path: "/projects/rom",
+          path: "/rom",
           output: "pages/rom.png",
           template: "page",
           data: {

--- a/app/templates/layouts/header/_nav_desktop.html.erb
+++ b/app/templates/layouts/header/_nav_desktop.html.erb
@@ -41,7 +41,7 @@
                 <% hanami, dry, rom = nav_item.children %>
 
                 <a
-                  href="/projects/hanami"
+                  href="/hanami"
                   class="
                     theme-hanami
                     flex flex-1 flex-col gap-2 p-5 pb-6 rounded-xl bg-neutral
@@ -64,7 +64,7 @@
 
                 <%# Dry %>
                 <a
-                  href="/projects/dry"
+                  href="/dry"
                   class="
                     theme-dry
                     flex flex-1 flex-col gap-2 p-5 pb-6 rounded-xl bg-neutral
@@ -87,7 +87,7 @@
 
                 <%# Rom %>
                 <a
-                  href="/projects/rom"
+                  href="/rom"
                   class="
                     theme-rom
                     flex flex-1 flex-col gap-2 p-5 pb-6 rounded-xl bg-neutral

--- a/app/templates/layouts/header/_nav_mobile.html.erb
+++ b/app/templates/layouts/header/_nav_mobile.html.erb
@@ -9,7 +9,7 @@
 
         <div class="flex gap-2 justify-center">
           <a
-            href="/projects/hanami"
+            href="/hanami"
             class="
               theme-hanami
               flex min-w-24 flex-col items-center gap-2 p-3 rounded-xl bg-neutral
@@ -24,7 +24,7 @@
           </a>
 
           <a
-            href="/projects/dry"
+            href="/dry"
             class="
               theme-dry
               flex min-w-24 flex-col items-center gap-2 p-3 rounded-xl bg-neutral
@@ -39,7 +39,7 @@
           </a>
 
           <a
-            href="/projects/rom"
+            href="/rom"
             class="
               theme-rom
               flex min-w-24 flex-col items-center gap-2 p-3 rounded-xl bg-neutral

--- a/app/templates/pages/home.html.erb
+++ b/app/templates/pages/home.html.erb
@@ -34,7 +34,7 @@
           description: <<~DESC,
             A complete framework for building apps with structure and clarity.
           DESC
-          primary_href: "/projects/hanami",
+          primary_href: "/hanami",
           primary_label: "Get building with Hanami",
           docs_href: "/learn/hanami" do |card| %>
       <%= card.slot :logo do %>
@@ -79,7 +79,7 @@
           description: <<~DESC,
             Validation, types, functional patterns and more, for robust code in any Ruby app.
           DESC
-          primary_href: "/projects/dry",
+          primary_href: "/dry",
           primary_label: "Dive into Dry",
           docs_href: "/learn/dry" do |card| %>
       <%= card.slot :logo do %>
@@ -123,7 +123,7 @@
           description: <<~DESC,
             A powerful, flexible persistence toolkit that keeps your domain logic clean.
           DESC
-          primary_href: "/projects/rom",
+          primary_href: "/rom",
           primary_label: "Tame your data with Rom",
           docs_href: "/learn/rom" do |card| %>
       <%= card.slot :logo do %>

--- a/app/view.rb
+++ b/app/view.rb
@@ -38,9 +38,9 @@ module Site
       path = context.request.path
       [
         NavItem.new(label: "Projects", url: "/projects", selected: path.start_with?("/projects"), children: [
-          NavItem.new(label: "Hanami", url: "/projects/hanami", selected: path.start_with?("/projects/hanami"), children: []),
-          NavItem.new(label: "Dry", url: "/projects/dry", selected: path.start_with?("/projects/dry"), children: []),
-          NavItem.new(label: "Rom", url: "/projects/rom", selected: path.start_with?("/projects/rom"), children: [])
+          NavItem.new(label: "Hanami", url: "/hanami", selected: path.start_with?("/hanami"), children: []),
+          NavItem.new(label: "Dry", url: "/dry", selected: path.start_with?("/dry"), children: []),
+          NavItem.new(label: "Rom", url: "/rom", selected: path.start_with?("/rom"), children: [])
         ]),
         NavItem.new(label: "Learn", url: "/learn", selected: path.start_with?("/learn"), children: []),
         NavItem.new(label: "Blog", url: "/blog", selected: path.start_with?("/blog"), children: []),
@@ -53,9 +53,9 @@ module Site
       path = context.request.path
       [
         NavItem.new(label: "Projects", url: nil, selected: false, children: [
-          NavItem.new(label: "Hanami", url: "/projects/hanami", selected: path.start_with?("/projects/hanami"), children: []),
-          NavItem.new(label: "Dry", url: "/projects/dry", selected: path.start_with?("/projects/dry"), children: []),
-          NavItem.new(label: "Rom", url: "/projects/rom", selected: path.start_with?("/projects/rom"), children: []),
+          NavItem.new(label: "Hanami", url: "/hanami", selected: path.start_with?("/hanami"), children: []),
+          NavItem.new(label: "Dry", url: "/dry", selected: path.start_with?("/dry"), children: []),
+          NavItem.new(label: "Rom", url: "/rom", selected: path.start_with?("/rom"), children: []),
           NavItem.new(label: "Status", url: "/status", selected: path.start_with?("/status"), children: [])
         ]),
         NavItem.new(label: "Learn", url: "/learn", selected: path.start_with?("/learn"), children: [

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,10 +36,9 @@ module Site
     get "/feed.xml", to: "feed.index"
 
     # Projects
-    redirect "/projects", to: "/"
-    get "/projects/hanami", to: "pages.hanami"
-    get "/projects/dry", to: "pages.dry"
-    get "/projects/rom", to: "pages.rom"
+    get "/hanami", to: "pages.hanami"
+    get "/dry", to: "pages.dry"
+    get "/rom", to: "pages.rom"
 
     # Special pages
     get "/community", to: "pages.community"


### PR DESCRIPTION
`/hanami` instead of `/projects/hanami`, etc.