### PR TITLE
Allow blank excerpts

### DIFF
--- a/app/structs/post.rb
+++ b/app/structs/post.rb
@@ -22,7 +22,7 @@ module Site
       end
 
       def excerpt
-        self[:excerpt] || "TODO"
+        self[:excerpt]
       end
 
       def show_toc?


### PR DESCRIPTION
Previously we fell back to a “TODO” string, but that’s obviously not very helpful for a real live site.

Fixes #343