### PR TITLE
Add fediverse:creator meta tag

### DIFF
--- a/app/templates/layouts/app.html.erb
+++ b/app/templates/layouts/app.html.erb
@@ -27,6 +27,8 @@
       type="image/svg+xml"
     >
 
+    <meta name="fediverse:creator" content="@hanakai@ruby.social">
+
     <%= render "shared/og_meta", title: content_for(:title), url: canonical_page_url, image: og_image_url, description: og_description, type: og_type %>
 
     <%= stylesheet_tag "app" %>


### PR DESCRIPTION
This will allow a special "More from" link to show under the preview of hanakai.org links shared on Mastodon.