### PR TITLE
Avoid FOUC with our brand text custom kerning

### DIFF
--- a/app/assets/js/views/replace-with-template.ts
+++ b/app/assets/js/views/replace-with-template.ts
@@ -7,17 +7,22 @@ import type { ViewFn } from "@icelab/defo";
  * element. Useful for progressive enhancement: render a simple, semantic
  * fallback in the source HTML and swap in a richer version once JS runs.
  *
+ * NOTE: the body of this function is mirrored as an inline <script> at the end
+ * of <body> in app/templates/layouts/app.html.erb, which runs synchronously
+ * before first paint to avoid a FOUC. Keep the two in sync. The code below is
+ * deliberately written so it can be copy-pasted between TS and inline JS
+ * unchanged (e.g. an `instanceof` runtime guard rather than a TS-only generic
+ * or type predicate).
+ *
  * @example
  * <span data-defo-replace-with-template>
  *   Hanami<template><span class="inline-flex">…kerned spans…</span></template>
  * </span>
  */
-export const replaceWithTemplateViewFn: ViewFn = (node: HTMLElement) => {
-  const template = Array.from(node.children).find(
-    (child): child is HTMLTemplateElement => child instanceof HTMLTemplateElement,
-  );
-  const replacement = template?.content.firstElementChild;
+export const replaceWithTemplateViewFn: ViewFn = (node) => {
+  const template = Array.from(node.children).find((c) => c instanceof HTMLTemplateElement);
+  if (!(template instanceof HTMLTemplateElement)) return;
+  const replacement = template.content.firstElementChild;
   if (!replacement) return;
-
   node.replaceChildren(replacement.cloneNode(true));
 };

--- a/app/templates/layouts/app.html.erb
+++ b/app/templates/layouts/app.html.erb
@@ -84,6 +84,23 @@
     <%= render "footer/base" %>
     <%= render "search/search_modal" %>
 
+    <%#
+      Run replaceWithTemplate synchronously before first paint to avoid a FOUC.
+      The body of the function below is a literal copy of replaceWithTemplateViewFn
+      in app/assets/js/views/replace-with-template.ts, which is loaded async and
+      would otherwise run after the page has painted. Keep the two in sync.
+    %>
+
+    <script>
+      document.querySelectorAll("[data-defo-replace-with-template]").forEach((node) => {
+        const template = Array.from(node.children).find((c) => c instanceof HTMLTemplateElement);
+        if (!(template instanceof HTMLTemplateElement)) return;
+        const replacement = template.content.firstElementChild;
+        if (!replacement) return;
+        node.replaceChildren(replacement.cloneNode(true));
+      });
+    </script>
+
     <% if tinylytics_site_id %>
       <script
         defer


### PR DESCRIPTION
Without this change, we get a little annoying jiggle in our main project name text (and "Hanakai" in the top nav) as we navigate between those pages.

Tackle this by inlining the replace-with-template code into a <script> tag at the end of the body, so it can run before the page paints.

@makenosound — what do you think?