### PR TITLE
Rename left footer section to “Hanakai”

### DIFF
--- a/app/templates/layouts/footer/_nav.html.erb
+++ b/app/templates/layouts/footer/_nav.html.erb
@@ -1,6 +1,6 @@
 <nav class="flex-1">
   <ul>
-    <%= render_with_slots "layouts/footer/nav_group", label: "Projects" do |g| %>
+    <%= render_with_slots "layouts/footer/nav_group", label: "Hanakai", url: "/" do |g| %>
       <% g.slot :items do %>
         <%= render "layouts/footer/nav_item", label: "Hanami", url: "/hanami" %>
         <%= render "layouts/footer/nav_item", label: "Dry", url: "/dry" %>


### PR DESCRIPTION
Link to the home page from here.

This gives us scope to add a few more “meta” pages to this column. In addition to the “Status” page, I plan to add a “Colophon”. This is where the “Brand” link can go too.