### PR TITLE
Show “Edit this page” link on guide pages

### DIFF
--- a/app/content.rb
+++ b/app/content.rb
@@ -17,6 +17,8 @@ module Site
     INDEX_PAGE_PATH = "_index"
     PAGES_FRONTMATTER_KEY = :pages
 
+    PAGE_EDIT_URL_BASE = "https://github.com/hanakai-rb/site/edit/main"
+
     class NotFoundError < StandardError
       attr_reader :path
 

--- a/app/content/page.rb
+++ b/app/content/page.rb
@@ -15,6 +15,14 @@ module Site
       attribute :front_matter, Types::Strict::Hash.constructor(->(hsh) { hsh.transform_keys(&:to_sym) })
       attribute :content, Types::Strict::String
       attribute :source_dir, Types::Strict::String.optional.default(nil)
+      attribute :source_file_path, Types::Strict::String.optional.default(nil)
+
+      def edit_url
+        return unless source_file_path
+
+        relative_path = Pathname(source_file_path).relative_path_from(Site::App.root)
+        "#{PAGE_EDIT_URL_BASE}/#{relative_path}"
+      end
 
       def title
         front_matter.fetch(:title)

--- a/app/content/page_collection.rb
+++ b/app/content/page_collection.rb
@@ -50,11 +50,11 @@ module Site
       private
 
       def build_page(path)
-        file_path = root.join(path)
+        file_path = "#{root.join(path)}.md"
 
         begin
           # Read file with explicit UTF-8 encoding
-          content = File.read("#{file_path}.md", encoding: "UTF-8")
+          content = File.read(file_path, encoding: "UTF-8")
           parsed_file = FrontMatterParser::Parser.new(:md).call(content)
         rescue Errno::ENOENT
           raise Content::NotFoundError, file_path
@@ -65,7 +65,8 @@ module Site
           url_path: (path == INDEX_PAGE_PATH) ? base_url_path : File.join(base_url_path, path),
           front_matter: parsed_file.front_matter,
           content: parsed_file.content,
-          source_dir: root.to_s
+          source_dir: root.to_s,
+          source_file_path: file_path
         )
       end
 

--- a/app/templates/doc_pages/_edit_page_link.html.erb
+++ b/app/templates/doc_pages/_edit_page_link.html.erb
@@ -1,0 +1,15 @@
+<% if edit_url %>
+  <p class="text-sm pt-4">
+    <a
+      class="
+        inline-flex items-center gap-2 text-link
+        hover:decoration-[3px] hover:underline
+        hover:decoration-(--hk-color-text-link-underline)
+      "
+      href="<%= edit_url %>"
+    >
+      <%= render "svgs/icons/notepad", width: 16, height: 16, class_name: "fill-current" %>
+      Edit this page
+    </a>
+  </p>
+<% end %>

--- a/app/templates/guides/show.html.erb
+++ b/app/templates/guides/show.html.erb
@@ -74,6 +74,8 @@
       <%= page.content_html %>
     </div>
 
+    <%= render "doc_pages/edit_page_link", edit_url: page.edit_url %>
+
     <%= render "doc_pages/next_prev_links",
         prev_item: prev_nav_item ? prev_nav_item : nil,
         next_item: next_nav_item ? next_nav_item : nil %>

--- a/spec/features/guides/guide_pages_spec.rb
+++ b/spec/features/guides/guide_pages_spec.rb
@@ -15,6 +15,24 @@ RSpec.feature "Guides / Guide pages" do
     expect(page).to have_selector "main header h1", text: "Context"
   end
 
+  it "renders an edit-on-GitHub link for the guide index page" do
+    visit "/learn/hanami/v2.2/views"
+
+    expect(page).to have_link(
+      "Edit this page",
+      href: "https://github.com/hanakai-rb/site/edit/main/content/guides/hanami/v2.2/views/_index.md"
+    )
+  end
+
+  it "renders an edit-on-GitHub link for a guide page" do
+    visit "/learn/hanami/v2.2/views/context"
+
+    expect(page).to have_link(
+      "Edit this page",
+      href: "https://github.com/hanakai-rb/site/edit/main/content/guides/hanami/v2.2/views/context.md"
+    )
+  end
+
   it "links to all the guide pages for an org" do
     visit "/learn/hanami/v2.2/views"
 


### PR DESCRIPTION
Make it easy for people to know what file to edit if they want to suggest corrections.

<img width="1205" height="653" alt="Screenshot 2026-05-02 at 10 06 48 am" src="https://github.com/user-attachments/assets/f6e3293d-cf06-434c-93b3-d00b204302fa" />

@makenosound Would you mind having a look at the styling here?

1. I'm not sure if the current placement is best
2. I reused the notepad icon, but there might be something better for this. Maybe a pencil or something?
3. Do we want some other styling to make it look more clickable?

Resolves #368 