### PR TITLE
Clarify dry-initializer inheritance guide

### DIFF
--- a/content/guides/dry/dry-initializer/v3.2/inheritance.md
+++ b/content/guides/dry/dry-initializer/v3.2/inheritance.md
@@ -21,21 +21,23 @@ employee = Employee.new('John', 'supercargo')
 employee.name     # => 'John'
 employee.position # => 'supercargo'
 
-employee = Employee.new # => fails because type
+employee = Employee.new # => fails with 'wrong number of arguments (given 0, expected 2+)'
 ```
 
 You can override params and options.
-Such overriding leaves initial order of params (positional arguments) unchanged:
+Overriding leaves the initial order of positional params unchanged:
 
 ```ruby
 class Employee < User
-  param :position, optional: true
-  param :name,     default:  proc { 'Unknown' }
+  # Caution! defining :position before :name does not change the order of positional params
+  param :position, default: proc { 'Manager' }
+  param :name,     default: proc { 'Jerry' }
 end
 
-user = User.new         # => Boom! because User#name is required
-employee = Employee.new # passes because who cares on employee's name
+# Employee initializer still expects :name as the first positional argument
+employee = Employee.new('John', 'supercargo')
+employee.name     # => 'John'
+employee.position # => 'supercargo'
 
-employee.name
-# => 'Unknown' because it is the name that positioned first like in User
+user = User.new # => Boom! because User#name is still required
 ```

--- a/content/guides/dry/dry-initializer/v3.2/inheritance.md
+++ b/content/guides/dry/dry-initializer/v3.2/inheritance.md
@@ -25,7 +25,7 @@ employee = Employee.new # => fails with 'wrong number of arguments (given 0, exp
 ```
 
 You can override params and options.
-Overriding leaves the initial order of positional params unchanged:
+Overriding leaves the initial order of params (positional arguments) unchanged:
 
 ```ruby
 class Employee < User
@@ -35,9 +35,9 @@ class Employee < User
 end
 
 # Employee initializer still expects :name as the first positional argument
-employee = Employee.new('John', 'supercargo')
+employee = Employee.new('John')
 employee.name     # => 'John'
-employee.position # => 'supercargo'
+employee.position # => 'Manager'
 
 user = User.new # => Boom! because User#name is still required
 ```


### PR DESCRIPTION
This changes the examples to directly highlight what is being talked about
and updates the language used for clarity