### PR TITLE
Change links to pass through internal links filter

### DIFF
--- a/app/content/filters/internal_links_filter.rb
+++ b/app/content/filters/internal_links_filter.rb
@@ -53,7 +53,8 @@ module Site
           replacement_proc = internal_links[uri.host.to_sym]
           return url unless replacement_proc
 
-          replacement_proc&.call(uri.path)
+          fragment = uri.fragment ? "#" + uri.fragment : ""
+          replacement_proc&.call(uri.path + fragment)
         end
 
         def internal_links = context[:internal_links]

--- a/content/guides/dry/dry-initializer/v3.2/type-constraints.md
+++ b/content/guides/dry/dry-initializer/v3.2/type-constraints.md
@@ -155,4 +155,4 @@ offset.location.parameter == offset # true
 ```
 
 [dry-types]: https://github.com/dry-rb/dry-types
-[dry-types-docs]: http://dry-rb.org/gems/dry-types/
+[dry-types-docs]: https://hanakai.org/learn/dry/dry-types/

--- a/content/guides/dry/dry-transaction/v0.16/custom-step-adapters.md
+++ b/content/guides/dry/dry-transaction/v0.16/custom-step-adapters.md
@@ -4,7 +4,7 @@ title: Custom step adapters
 
 You can provide your own step adapters to add custom behaviour to transaction steps. Your step adapters must provide a single `#call(step, input, *args)` method, which should return the step’s result wrapped in a `Result` object.
 
-You can provide your step adapter in a few different ways. You can add it to the built-in `StepAdapters` container (a [`dry-container`](http://dry-rb.org/gems/dry-container)) to make it available to all transactions in your codebase:
+You can provide your step adapter in a few different ways. You can add it to the built-in `StepAdapters` container (a [`dry-container`](//org_guide/dry/dry-container)) to make it available to all transactions in your codebase:
 
 ```ruby
 Dry::Transaction::StepAdapters.register :custom_adapter, MyAdapter.new

--- a/content/guides/hanami/v2.0/actions/parameters.md
+++ b/content/guides/hanami/v2.0/actions/parameters.md
@@ -205,9 +205,9 @@ For an empty `POST` request with an empty address object, this action would rend
 }
 ```
 
-Action validations use the [dry-validation](https://dry-rb.org/gems/dry-validation/) gem, which provides a powerful DSL for defining schemas.
+Action validations use the [dry-validation](//org_guide/dry/dry-validation) gem, which provides a powerful DSL for defining schemas.
 
-Consult the [dry-validation](https://dry-rb.org/gems/dry-validation/) and [dry-schema](https://dry-rb.org/gems/dry-schema/) gems for further documentation.
+Consult the [dry-validation](//org_guide/dry/dry-validation) and [dry-schema](//org_guide/dry/dry-schema) gems for further documentation.
 
 ## Using concrete classes
 

--- a/content/guides/hanami/v2.0/app/inflector.md
+++ b/content/guides/hanami/v2.0/app/inflector.md
@@ -2,7 +2,7 @@
 title: Inflector
 ---
 
-Hanami includes an inflector that supports the pluralization, singularization and humanization of English words, as well as other transformations. This inflector is a [Dry::Inflector](https://dry-rb.org/gems/dry-inflector) instance.
+Hanami includes an inflector that supports the pluralization, singularization and humanization of English words, as well as other transformations. This inflector is a [Dry::Inflector](//org_guide/dry/dry-inflector) instance.
 
 Hanami uses the inflector internally for a variety of purposes, but it's also available to use in your own code via the `"inflector"` component.
 

--- a/content/guides/hanami/v2.0/app/settings.md
+++ b/content/guides/hanami/v2.0/app/settings.md
@@ -75,7 +75,7 @@ Types::Params::Date
 Types::Params::Time
 ```
 
-These types are provided by [dry-types](https://dry-rb.org/gems/dry-types), and the `Types` module is generated for you automatically when you subclass `Hanami::Settings`.
+These types are provided by [dry-types](//org_guide/dry/dry-types), and the `Types` module is generated for you automatically when you subclass `Hanami::Settings`.
 
 ## Required and optional settings
 
@@ -146,7 +146,7 @@ end
 
 ## Constraints
 
-To enforce additional contraints on settings, you can use a [constraint](https://dry-rb.org/gems/dry-types/1.2/constraints/) in your constructor type.
+To enforce additional contraints on settings, you can use a [constraint](//org_guide/dry/dry-types/constraints) in your constructor type.
 
 Here, the value of the `session_secret` must be at least 32 characters, while the value of the `from_email` setting must satisfy the EMAIL_FORMAT regular expression:
 

--- a/content/guides/hanami/v2.0/getting-started/_index.md
+++ b/content/guides/hanami/v2.0/getting-started/_index.md
@@ -760,9 +760,7 @@ module Bookshelf
 end
 ```
 
-<p class="convention">
-  Accessing relations directly from actions is not a commonly recommended pattern. Instead, a <a href="https://rom-rb.org/5.0/learn/repositories/quick-start/">rom repository</a> should be used. Here, however, the repository is ommitted for brevity. Hanami's 2.2 release will offer repositories out of the box.
-</p>
+Accessing relations directly from actions is not a commonly recommended pattern. Instead, a [rom repository](//org_guide/rom/repositories/quick-start) should be used. Here, however, the repository is ommitted for brevity. Hanami's 2.2 release will offer repositories out of the box.
 
 With this action in place, the spec passes once more:
 

--- a/content/guides/hanami/v2.1/actions/parameters.md
+++ b/content/guides/hanami/v2.1/actions/parameters.md
@@ -205,9 +205,9 @@ For an empty `POST` request with an empty address object, this action would rend
 }
 ```
 
-Action validations use the [dry-validation](https://dry-rb.org/gems/dry-validation/) gem, which provides a powerful DSL for defining schemas.
+Action validations use the [dry-validation](//org_guide/dry/dry-validation) gem, which provides a powerful DSL for defining schemas.
 
-Consult the [dry-validation](https://dry-rb.org/gems/dry-validation/) and [dry-schema](https://dry-rb.org/gems/dry-schema/) gems for further documentation.
+Consult the [dry-validation](//org_guide/dry/dry-validation) and [dry-schema](//org_guide/dry/dry-schema) gems for further documentation.
 
 ## Using concrete classes
 

--- a/content/guides/hanami/v2.1/app/inflector.md
+++ b/content/guides/hanami/v2.1/app/inflector.md
@@ -2,7 +2,7 @@
 title: Inflector
 ---
 
-Hanami includes an inflector that supports the pluralization, singularization and humanization of English words, as well as other transformations. This inflector is a [Dry::Inflector](https://dry-rb.org/gems/dry-inflector) instance.
+Hanami includes an inflector that supports the pluralization, singularization and humanization of English words, as well as other transformations. This inflector is a [Dry::Inflector](//org_guide/dry/dry-inflector) instance.
 
 Hanami uses the inflector internally for a variety of purposes, but it's also available to use in your own code via the `"inflector"` component.
 

--- a/content/guides/hanami/v2.1/app/settings.md
+++ b/content/guides/hanami/v2.1/app/settings.md
@@ -75,7 +75,7 @@ Types::Params::Date
 Types::Params::Time
 ```
 
-These types are provided by [dry-types](https://dry-rb.org/gems/dry-types), and the `Types` module is generated for you automatically when you subclass `Hanami::Settings`.
+These types are provided by [dry-types](//org_guide/dry/dry-types), and the `Types` module is generated for you automatically when you subclass `Hanami::Settings`.
 
 ## Required and optional settings
 
@@ -146,7 +146,7 @@ end
 
 ## Constraints
 
-To enforce additional contraints on settings, you can use a [constraint](https://dry-rb.org/gems/dry-types/1.2/constraints/) in your constructor type.
+To enforce additional contraints on settings, you can use a [constraint](//org_guide/dry/dry-types/constraints) in your constructor type.
 
 Here, the value of the `session_secret` must be at least 32 characters, while the value of the `from_email` setting must satisfy the EMAIL_FORMAT regular expression:
 

--- a/content/guides/hanami/v2.1/getting-started/building-a-web-app.md
+++ b/content/guides/hanami/v2.1/getting-started/building-a-web-app.md
@@ -617,9 +617,7 @@ module Bookshelf
 end
 ```
 
-<p class="convention">
-  Accessing relations directly from app components like views and actions is not a commonly recommended pattern. Instead, a <a href="https://rom-rb.org/5.0/learn/repositories/quick-start/">ROM repository</a> should be used. Here, however, the repository is ommitted for brevity. Hanami's 2.2 release will offer repositories out of the box.
-</p>
+Accessing relations directly from app components like views and actions is not a commonly recommended pattern. Instead, a [ROM repository](//org_guide/rom/repositories/quick-start) should be used. Here, however, the repository is ommitted for brevity. Hanami's 2.2 release will offer repositories out of the box.
 
 Then we can update our template to include the author:
 

--- a/content/guides/hanami/v2.1/getting-started/building-an-api.md
+++ b/content/guides/hanami/v2.1/getting-started/building-an-api.md
@@ -621,9 +621,7 @@ module Bookshelf
 end
 ```
 
-<p class="convention">
-  Accessing relations directly from actions is not a commonly recommended pattern. Instead, a <a href="https://rom-rb.org/5.0/learn/repositories/quick-start/">rom repository</a> should be used. Here, however, the repository is ommitted for brevity. Hanami's 2.2 release will offer repositories out of the box.
-</p>
+Accessing relations directly from actions is not a commonly recommended pattern. Instead, a [rom repository](//org_guide/rom/repositories/quick-start) should be used. Here, however, the repository is ommitted for brevity. Hanami's 2.2 release will offer repositories out of the box.
 
 With this action in place, the spec passes once more:
 

--- a/content/guides/hanami/v2.2/actions/parameters.md
+++ b/content/guides/hanami/v2.2/actions/parameters.md
@@ -205,9 +205,9 @@ For an empty `POST` request with an empty address object, this action would rend
 }
 ```
 
-Action validations use the [dry-validation](https://dry-rb.org/gems/dry-validation/) gem, which provides a powerful DSL for defining schemas.
+Action validations use the [dry-validation](//org_guide/dry/dry-validation) gem, which provides a powerful DSL for defining schemas.
 
-Consult the [dry-validation](https://dry-rb.org/gems/dry-validation/) and [dry-schema](https://dry-rb.org/gems/dry-schema/) gems for further documentation.
+Consult the [dry-validation](//org_guide/dry/dry-validation) and [dry-schema](//org_guide/dry/dry-schema) gems for further documentation.
 
 ## Using concrete classes
 

--- a/content/guides/hanami/v2.2/app/inflector.md
+++ b/content/guides/hanami/v2.2/app/inflector.md
@@ -2,7 +2,7 @@
 title: Inflector
 ---
 
-Hanami includes an inflector that supports the pluralization, singularization and humanization of English words, as well as other transformations. This inflector is a [Dry::Inflector](https://dry-rb.org/gems/dry-inflector) instance.
+Hanami includes an inflector that supports the pluralization, singularization and humanization of English words, as well as other transformations. This inflector is a [Dry::Inflector](//org_guide/dry/dry-inflector) instance.
 
 Hanami uses the inflector internally for a variety of purposes, but it's also available to use in your own code via the `"inflector"` component.
 

--- a/content/guides/hanami/v2.2/app/settings.md
+++ b/content/guides/hanami/v2.2/app/settings.md
@@ -75,7 +75,7 @@ Types::Params::Date
 Types::Params::Time
 ```
 
-These types are provided by [dry-types](https://dry-rb.org/gems/dry-types), and the `Types` module is generated for you automatically when you subclass `Hanami::Settings`.
+These types are provided by [dry-types](//org_guide/dry/dry-types), and the `Types` module is generated for you automatically when you subclass `Hanami::Settings`.
 
 ## Required and optional settings
 
@@ -146,7 +146,7 @@ end
 
 ## Constraints
 
-To enforce additional contraints on settings, you can use a [constraint](https://dry-rb.org/gems/dry-types/1.2/constraints/) in your constructor type.
+To enforce additional contraints on settings, you can use a [constraint](//org_guide/dry/dry-types/constraints) in your constructor type.
 
 Here, the value of the `session_secret` must be at least 32 characters, while the value of the `from_email` setting must satisfy the EMAIL_FORMAT regular expression:
 

--- a/content/guides/hanami/v2.2/database/_index.md
+++ b/content/guides/hanami/v2.2/database/_index.md
@@ -15,7 +15,7 @@ Above all else ROM favors:
 - **Speed**, because performance is a _feature_
 - **Flexibility** in your domain layer's design
 
-[ROM: Principles & Design](https://rom-rb.org/learn/#principles-amp-design)
+[ROM: Principles & Design](//org_guide/rom#principles--design)
 
 </blockquote>
 
@@ -115,7 +115,7 @@ end
 
 If the rest of your business logic treats the identity as an opaque string, then you’re done. The encapsulation afforded by Repository restricts the knowledge of the persistence layer from where it does not belong.
 
-For more on Repositories, see [ROM: Repositories](https://rom-rb.org/learn/repository/5.2/)
+For more on Repositories, see [ROM: Repositories](//org_guide/rom/repositories)
 
 ## Structs
 

--- a/content/guides/hanami/v2.2/database/configuration.md
+++ b/content/guides/hanami/v2.2/database/configuration.md
@@ -22,7 +22,7 @@ DATABASE_URL=mysql2://user:password@localhost/bookshelf_dev
 DATABASE_URL=sqlite://config/db/development.sqlite
 ```
 
-For more detail on the syntax of the URLs, see [ROM SQL: Connecting to a Database](https://rom-rb.org/learn/sql/3.3/#connecting-to-a-database)
+For more detail on the syntax of the URLs, see [ROM SQL: Connecting to a Database](//org_guide/rom/sql#connecting-to-a-database)
 
 ## Advanced Configuration
 

--- a/content/guides/hanami/v2.2/database/relations.md
+++ b/content/guides/hanami/v2.2/database/relations.md
@@ -72,7 +72,7 @@ books.by_pk(id).one
 # => { id: 1, title: "Hanami", status: :released }
 ```
 
-The Types namespace available to Relations comes from `ROM::SQL::Types` and is built from [dry-types](https://dry-rb.org/gems/dry-types/).
+The Types namespace available to Relations comes from `ROM::SQL::Types` and is built from [dry-types](//org_guide/dry/dry-types).
 
 Normally, dry-types model a single type with optional coercion logic. However, SQL introduces a two-fold coercion due to the difference between SQL and Ruby types. When these types diverge, the first type argument is the SQL type to be written, and you pass a `read:` argument with the Ruby type.
 

--- a/content/guides/hanami/v2.2/operations/_index.md
+++ b/content/guides/hanami/v2.2/operations/_index.md
@@ -6,7 +6,7 @@ title: Overview
 
 Operations organize business logic in Hanami apps. They are the foundation of your app’s "service layer".
 
-Operations are built using [dry-operation](https://dry-rb.org/gems/dry-operation/1.0/).
+Operations are built using [dry-operation](//org_guide/dry/dry-operation).
 
 With operations, you can model your logic as a linear flow of steps, each returning a `Success` or `Failure`. If all steps of an operation succeed, the operation completes and returns its final value as a success. If any step returns a failure, execution short circuits and returns that failure immediately.
 
@@ -89,7 +89,7 @@ module Bookshelf
 end
 ```
 
-To learn more about operations, see [the dry-operation documentation](https://dry-rb.org/gems/dry-operation/1.0/).
+To learn more about operations, see [the dry-operation documentation](//org_guide/dry/dry-operation).
 
 ## Database transactions
 

--- a/content/guides/hanami/v2.3/actions/parameters.md
+++ b/content/guides/hanami/v2.3/actions/parameters.md
@@ -205,9 +205,9 @@ For an empty `POST` request with an empty address object, this action would rend
 }
 ```
 
-Action validations use the [dry-validation](https://dry-rb.org/gems/dry-validation/) gem, which provides a powerful DSL for defining schemas.
+Action validations use the [dry-validation](//org_guide/dry/dry-validation) gem, which provides a powerful DSL for defining schemas.
 
-Consult the [dry-validation](https://dry-rb.org/gems/dry-validation/) and [dry-schema](https://dry-rb.org/gems/dry-schema/) gems for further documentation.
+Consult the [dry-validation](//org_guide/dry/dry-validation) and [dry-schema](//org_guide/dry/dry-schema) gems for further documentation.
 
 ## Using concrete classes
 

--- a/content/guides/hanami/v2.3/app/inflector.md
+++ b/content/guides/hanami/v2.3/app/inflector.md
@@ -2,7 +2,7 @@
 title: Inflector
 ---
 
-Hanami includes an inflector that supports the pluralization, singularization and humanization of English words, as well as other transformations. This inflector is a [Dry::Inflector](https://dry-rb.org/gems/dry-inflector) instance.
+Hanami includes an inflector that supports the pluralization, singularization and humanization of English words, as well as other transformations. This inflector is a [Dry::Inflector](//org_guide/dry/dry-inflector) instance.
 
 Hanami uses the inflector internally for a variety of purposes, but it's also available to use in your own code via the `"inflector"` component.
 

--- a/content/guides/hanami/v2.3/app/settings.md
+++ b/content/guides/hanami/v2.3/app/settings.md
@@ -75,7 +75,7 @@ Types::Params::Date
 Types::Params::Time
 ```
 
-These types are provided by [dry-types](https://dry-rb.org/gems/dry-types), and the `Types` module is generated for you automatically when you subclass `Hanami::Settings`.
+These types are provided by [dry-types](//org_guide/dry/dry-types), and the `Types` module is generated for you automatically when you subclass `Hanami::Settings`.
 
 ## Required and optional settings
 
@@ -146,7 +146,7 @@ end
 
 ## Constraints
 
-To enforce additional contraints on settings, you can use a [constraint](https://dry-rb.org/gems/dry-types/1.2/constraints/) in your constructor type.
+To enforce additional contraints on settings, you can use a [constraint](//org_guide/dry/dry-types/constraints) in your constructor type.
 
 Here, the value of the `session_secret` must be at least 32 characters, while the value of the `from_email` setting must satisfy the EMAIL_FORMAT regular expression:
 

--- a/content/guides/hanami/v2.3/database/_index.md
+++ b/content/guides/hanami/v2.3/database/_index.md
@@ -14,7 +14,7 @@ Above all else ROM favors:
 - **Speed**, because performance is a _feature_
 - **Flexibility** in your domain layer's design
 
-[ROM: Principles & Design](https://rom-rb.org/learn/#principles-amp-design)
+[ROM: Principles & Design](//org_guide/rom#principles--design)
 
 While traditional Object-Relational Mapping comes from a strictly Object-Oriented approach, ROM combines the best parts of Functional Programming and OOP that play to Ruby’s inherent strengths as a language. Instead of homogenizing all datastores into a lowest-common-denominator API, ROM embraces the diversity of storage engines and the powerful features they can provide.
 
@@ -112,7 +112,7 @@ end
 
 If the rest of your business logic treats the identity as an opaque string, then you’re done. The encapsulation afforded by Repository restricts the knowledge of the persistence layer from where it does not belong.
 
-For more on Repositories, see [ROM: Repositories](https://rom-rb.org/learn/repository/5.2/)
+For more on Repositories, see [ROM: Repositories](//org_guide/rom/repositories)
 
 ## Structs
 

--- a/content/guides/hanami/v2.3/database/configuration.md
+++ b/content/guides/hanami/v2.3/database/configuration.md
@@ -40,7 +40,7 @@ DATABASE_URL=postgres://localhost/bookshelf_development
 DATABASE_URL=mysql2://user:password@localhost/bookshelf_dev
 ```
 
-For more detail on the syntax of the URLs, see [ROM SQL: Connecting to a Database](https://rom-rb.org/learn/sql/3.3/#connecting-to-a-database)
+For more detail on the syntax of the URLs, see [ROM SQL: Connecting to a Database](//org_guide/rom/sql#connecting-to-a-database)
 
 ## Advanced Configuration
 

--- a/content/guides/hanami/v2.3/database/relations.md
+++ b/content/guides/hanami/v2.3/database/relations.md
@@ -71,7 +71,7 @@ books.by_pk(id).one
 # => { id: 1, title: "Hanami", status: :released }
 ```
 
-The Types namespace available to Relations comes from `ROM::SQL::Types` and is built from [dry-types](https://dry-rb.org/gems/dry-types/).
+The Types namespace available to Relations comes from `ROM::SQL::Types` and is built from [dry-types](//org_guide/dry/dry-types).
 
 Normally, dry-types model a single type with optional coercion logic. However, SQL introduces a two-fold coercion due to the difference between SQL and Ruby types. When these types diverge, the first type argument is the SQL type to be written, and you pass a `read:` argument with the Ruby type.
 

--- a/content/guides/hanami/v2.3/operations/_index.md
+++ b/content/guides/hanami/v2.3/operations/_index.md
@@ -6,7 +6,7 @@ title: Overview
 
 Operations organize business logic in Hanami apps. They are the foundation of your app’s "service layer".
 
-Operations are built using [dry-operation](https://dry-rb.org/gems/dry-operation/1.0/).
+Operations are built using [dry-operation](//org_guide/dry/dry-operation).
 
 With operations, you can model your logic as a linear flow of steps, each returning a `Success` or `Failure`. If all steps of an operation succeed, the operation completes and returns its final value as a success. If any step returns a failure, execution short circuits and returns that failure immediately.
 
@@ -89,7 +89,7 @@ module Bookshelf
 end
 ```
 
-To learn more about operations, see [the dry-operation documentation](https://dry-rb.org/gems/dry-operation/1.0/).
+To learn more about operations, see [the dry-operation documentation](//org_guide/dry/dry-operation).
 
 ## Database transactions
 
@@ -142,4 +142,4 @@ end
 
 This pattern matching allows you to handle different types of failures in a clear and explicit manner.
 
-Operations' `Success` and `Failure` results come from dry-monads. To learn more about working with results, see the [dry-monads result documentation](https://dry-rb.org/gems/dry-monads/1.6/result/).
+Operations' `Success` and `Failure` results come from dry-monads. To learn more about working with results, see the [dry-monads result documentation](//org_guide/dry/dry-monads/result).

--- a/content/guides/hanami/v3.0/actions/parameters.md
+++ b/content/guides/hanami/v3.0/actions/parameters.md
@@ -205,9 +205,9 @@ For an empty `POST` request with an empty address object, this action would rend
 }
 ```
 
-Action validations use the [dry-validation](https://dry-rb.org/gems/dry-validation/) gem, which provides a powerful DSL for defining schemas.
+Action validations use the [dry-validation](//org_guide/dry/dry-validation) gem, which provides a powerful DSL for defining schemas.
 
-Consult the [dry-validation](https://dry-rb.org/gems/dry-validation/) and [dry-schema](https://dry-rb.org/gems/dry-schema/) gems for further documentation.
+Consult the [dry-validation](//org_guide/dry/dry-validation) and [dry-schema](//org_guide/dry/dry-schema) gems for further documentation.
 
 ## Using concrete classes
 

--- a/content/guides/hanami/v3.0/app/inflector.md
+++ b/content/guides/hanami/v3.0/app/inflector.md
@@ -2,7 +2,7 @@
 title: Inflector
 ---
 
-Hanami includes an inflector that supports the pluralization, singularization and humanization of English words, as well as other transformations. This inflector is a [Dry::Inflector](https://dry-rb.org/gems/dry-inflector) instance.
+Hanami includes an inflector that supports the pluralization, singularization and humanization of English words, as well as other transformations. This inflector is a [Dry::Inflector](//org_guide/dry/dry-inflector) instance.
 
 Hanami uses the inflector internally for a variety of purposes, but it's also available to use in your own code via the `"inflector"` component.
 

--- a/content/guides/hanami/v3.0/app/settings.md
+++ b/content/guides/hanami/v3.0/app/settings.md
@@ -75,7 +75,7 @@ Types::Params::Date
 Types::Params::Time
 ```
 
-These types are provided by [dry-types](https://dry-rb.org/gems/dry-types), and the `Types` module is generated for you automatically when you subclass `Hanami::Settings`.
+These types are provided by [dry-types](//org_guide/dry/dry-types), and the `Types` module is generated for you automatically when you subclass `Hanami::Settings`.
 
 ## Required and optional settings
 
@@ -146,7 +146,7 @@ end
 
 ## Constraints
 
-To enforce additional contraints on settings, you can use a [constraint](https://dry-rb.org/gems/dry-types/1.2/constraints/) in your constructor type.
+To enforce additional contraints on settings, you can use a [constraint](//org_guide/dry/dry-types/constraints) in your constructor type.
 
 Here, the value of the `session_secret` must be at least 32 characters, while the value of the `from_email` setting must satisfy the EMAIL_FORMAT regular expression:
 

--- a/content/guides/hanami/v3.0/database/_index.md
+++ b/content/guides/hanami/v3.0/database/_index.md
@@ -14,7 +14,7 @@ Above all else ROM favors:
 - **Speed**, because performance is a _feature_
 - **Flexibility** in your domain layer's design
 
-[ROM: Principles & Design](https://rom-rb.org/learn/#principles-amp-design)
+[ROM: Principles & Design](//org_guide/rom#principles--design)
 
 While traditional Object-Relational Mapping comes from a strictly Object-Oriented approach, ROM combines the best parts of Functional Programming and OOP that play to Ruby’s inherent strengths as a language. Instead of homogenizing all datastores into a lowest-common-denominator API, ROM embraces the diversity of storage engines and the powerful features they can provide.
 
@@ -112,7 +112,7 @@ end
 
 If the rest of your business logic treats the identity as an opaque string, then you’re done. The encapsulation afforded by Repository restricts the knowledge of the persistence layer from where it does not belong.
 
-For more on Repositories, see [ROM: Repositories](https://rom-rb.org/learn/repository/5.2/)
+For more on Repositories, see [ROM: Repositories](//org_guide/rom/repositories)
 
 ## Structs
 

--- a/content/guides/hanami/v3.0/database/configuration.md
+++ b/content/guides/hanami/v3.0/database/configuration.md
@@ -40,7 +40,7 @@ DATABASE_URL=postgres://localhost/bookshelf_development
 DATABASE_URL=mysql2://user:password@localhost/bookshelf_dev
 ```
 
-For more detail on the syntax of the URLs, see [ROM SQL: Connecting to a Database](https://rom-rb.org/learn/sql/3.3/#connecting-to-a-database)
+For more detail on the syntax of the URLs, see [ROM SQL: Connecting to a Database](//org_guide/rom/sql#connecting-to-a-database)
 
 ## Advanced Configuration
 

--- a/content/guides/hanami/v3.0/database/relations.md
+++ b/content/guides/hanami/v3.0/database/relations.md
@@ -71,7 +71,7 @@ books.by_pk(id).one
 # => { id: 1, title: "Hanami", status: :released }
 ```
 
-The Types namespace available to Relations comes from `ROM::SQL::Types` and is built from [dry-types](https://dry-rb.org/gems/dry-types/).
+The Types namespace available to Relations comes from `ROM::SQL::Types` and is built from [dry-types](//org_guide/dry/dry-types).
 
 Normally, dry-types model a single type with optional coercion logic. However, SQL introduces a two-fold coercion due to the difference between SQL and Ruby types. When these types diverge, the first type argument is the SQL type to be written, and you pass a `read:` argument with the Ruby type.
 

--- a/content/guides/hanami/v3.0/operations/_index.md
+++ b/content/guides/hanami/v3.0/operations/_index.md
@@ -6,7 +6,7 @@ title: Overview
 
 Operations organize business logic in Hanami apps. They are the foundation of your app’s "service layer".
 
-Operations are built using [dry-operation](https://dry-rb.org/gems/dry-operation/1.0/).
+Operations are built using [dry-operation](//org_guide/dry/dry-operation).
 
 With operations, you can model your logic as a linear flow of steps, each returning a `Success` or `Failure`. If all steps of an operation succeed, the operation completes and returns its final value as a success. If any step returns a failure, execution short circuits and returns that failure immediately.
 
@@ -89,7 +89,7 @@ module Bookshelf
 end
 ```
 
-To learn more about operations, see [the dry-operation documentation](https://dry-rb.org/gems/dry-operation/1.0/).
+To learn more about operations, see [the dry-operation documentation](//org_guide/dry/dry-operation).
 
 ## Database transactions
 
@@ -142,4 +142,4 @@ end
 
 This pattern matching allows you to handle different types of failures in a clear and explicit manner.
 
-Operations' `Success` and `Failure` results come from dry-monads. To learn more about working with results, see the [dry-monads result documentation](https://dry-rb.org/gems/dry-monads/1.6/result/).
+Operations' `Success` and `Failure` results come from dry-monads. To learn more about working with results, see the [dry-monads result documentation](//org_guide/dry/dry-monads/result).

--- a/content/guides/rom/v5.0/core-concepts/schemas.md
+++ b/content/guides/rom/v5.0/core-concepts/schemas.md
@@ -160,7 +160,7 @@ Now when `Users` relation reads it data, `birthday` values will be processed via
 
 ## Type System
 
-Schemas use a type system from [dry-types](http://dry-rb.org/gems/dry-types) and you can define your own schema types however you want. What types you need really depends on your application requirements, the adapter you're using, specific use cases of your application and so on.
+Schemas use a type system from [dry-types](//org_guide/dry/dry-types) and you can define your own schema types however you want. What types you need really depends on your application requirements, the adapter you're using, specific use cases of your application and so on.
 
 Here are a couple of guidelines that should help you in making right decisions:
 


### PR DESCRIPTION
Some links in the documents (e.g. https://rom-rb.org/learn/sql/3.3/#connecting-to-a-database) shows 404 so I suggest changing rom-rb.org/learn links and dry-rb.org/gems links to pass through internal links filter.

and URI fragments gets missing after processing internal links filter, so I added some lines to preserve those fragments.