### PR TITLE
Remove dry-equalizer from Dry page

### DIFF
--- a/content/guides/dry/dry-equalizer/v0.3/_index.md
+++ b/content/guides/dry/dry-equalizer/v0.3/_index.md
@@ -1,8 +1,0 @@
----
-title: Introduction & Usage
----
-
-# DEPRECATED
-
-This functionality has been moved to [`dry-core`](//page/dry-core), with an identical API.
-To update, change your code to `Dry::Core::Equalizer`and `require 'dry/core/equalizer'`.

--- a/legacy-redirects/dry-rb.org/_redirects
+++ b/legacy-redirects/dry-rb.org/_redirects
@@ -38,8 +38,8 @@
 /gems/dry-files/:version/*          https://hanakai.org/learn/dry/dry-files/:splat
 /gems/dry-auto_inject               https://hanakai.org/learn/dry/dry-auto_inject
 /gems/dry-auto_inject/:version/*    https://hanakai.org/learn/dry/dry-auto_inject/:splat
-/gems/dry-equalizer                 https://hanakai.org/learn/dry/dry-equalizer
-/gems/dry-equalizer/:version/*      https://hanakai.org/learn/dry/dry-equalizer/:splat
+/gems/dry-equalizer                 https://hanakai.org/learn/dry/dry-core/equalizer
+/gems/dry-equalizer/:version/*      https://hanakai.org/learn/dry/dry-core/equalizer
 /gems/dry-events                    https://hanakai.org/learn/dry/dry-events
 /gems/dry-events/:version/*         https://hanakai.org/learn/dry/dry-events/:splat
 /gems/dry-inflector                 https://hanakai.org/learn/dry/dry-inflector


### PR DESCRIPTION
The link on this page https://hanakai.org/learn/dry/dry-equalizer/v0.3 to dry-core is broken. I was going to fix that, but we don't need this gem on the site at all anymore.