### PR TITLE
Fix Cmd+K activating address bar in Firefox

### DIFF
--- a/app/assets/js/views/pagefind-search.ts
+++ b/app/assets/js/views/pagefind-search.ts
@@ -191,6 +191,8 @@ export const pagefindSearchViewFn: ViewFn<Props> = (
   const onKeyDown = (e: KeyboardEvent) => {
     // Activate on Ctrl/Cmd + K
     if (!active && e.metaKey && e.key === "k") {
+      // prevent Firefox focusing on address bar
+      e.preventDefault();
       activate();
     }
     // Deactivate on Escape (unless we’re in the search input)


### PR DESCRIPTION
This affects Firefox and Zen Browser at least, but may affect other browsers too.

See screen recording for bug after pressing Cmd+K:

https://github.com/user-attachments/assets/44cf7f2d-bc07-42cc-8d1d-562aef81896b

