### PR TITLE
Convert all `.(…)` references to `.call(…)`

### DIFF
--- a/content/guides/dry/dry-effects/v0.5/_index.md
+++ b/content/guides/dry/dry-effects/v0.5/_index.md
@@ -34,7 +34,7 @@ class CounterMiddleware
   def call(env)
     # Calling `with_counter` makes the value available anywhere in `@app.call`
     counter, response = with_counter(0) do
-      @app.(env)
+      @app.call(env)
     end
 
     # Once processing is complete, the result value
@@ -70,7 +70,7 @@ RSpec.describe CreatePost do
   subject(:create_post) { described_class.new }
 
   it 'updates the counter' do
-    counter, post = with_counter(0) { create_post.(post_values) }
+    counter, post = with_counter(0) { create_post.call(post_values) }
 
     expect(counter).to be(1)
   end
@@ -80,7 +80,7 @@ end
 Any introduced effect must have a handler. If no handler found you'll see an error:
 
 ```ruby
-CreatePost.new.({})
+CreatePost.new.call({})
 # => Dry::Effects::Errors::MissingStateError (Value of +counter+ is not set, you need to provide value with an effect handler)
 ```
 
@@ -105,7 +105,7 @@ class TestNewFeatureMiddleware
 
   def call(env)
     without_feature, with_feature = test_feature do
-      @app.(env)
+      @app.call(env)
     end
 
     if with_feature != without_feature
@@ -170,13 +170,13 @@ class Context
   def call(name)
     test_excitement do
       with_greetings_given(0) do
-        @greeting.(name)
+        @greeting.call(name)
       end
     end
   end
 end
 
-Context.new.('Alice')
+Context.new.call('Alice')
 # => [[1, "1. Hello Alice"], [1, "1. Hello Alice!"]]
 ```
 
@@ -188,13 +188,13 @@ class Context
   def call(name)
     with_greetings_given(0) do
       test_excitement do
-        @greeting.(name)
+        @greeting.call(name)
       end
     end
   end
 end
 
-Context.new.('Alice')
+Context.new.call('Alice')
 # => [2, ["1. Hello Alice", "2. Hello Alice!"]]
 ```
 

--- a/content/guides/dry/dry-effects/v0.5/effects/cache.md
+++ b/content/guides/dry/dry-effects/v0.5/effects/cache.md
@@ -77,6 +77,6 @@ require 'dry/effects'
 with_cache = Object.new.extend(Dry::Effects::Handler.Cache(:my_app, as: :call))
 
 RSpec.configure do |config|
-  config.around(:each) { with_cache.(&ex) }
+  config.around(:each) { with_cache.call(&ex) }
 end
 ```

--- a/content/guides/dry/dry-effects/v0.5/effects/current_time.md
+++ b/content/guides/dry/dry-effects/v0.5/effects/current_time.md
@@ -19,7 +19,7 @@ class CurrentTimeMiddleware
   def call(env)
     # It will use Time.now internally once and set it fixed
     with_current_time do
-      @app.(env)
+      @app.call(env)
     end
   end
 end
@@ -162,7 +162,7 @@ class CurrentTimeMiddleware
 
   def call(env)
     with_current_time(overridable: ENV['RACK_ENV'].eql?('test')) do
-      @app.(env)
+      @app.call(env)
     end
   end
 end

--- a/content/guides/dry/dry-effects/v0.5/effects/defer.md
+++ b/content/guides/dry/dry-effects/v0.5/effects/defer.md
@@ -19,7 +19,7 @@ class CreateUser
 
   def call(values)
     user = user_repo.create(values)
-    defer { send_invitation.(user) }
+    defer { send_invitation.call(user) }
     user
   end
 end
@@ -47,7 +47,7 @@ class HandleDefer
 
   def call(env)
     # defer tasks in @app will be run on the same thread
-    with_defer { @app.(env) }
+    with_defer { @app.call(env) }
   end
 end
 ```
@@ -56,7 +56,7 @@ The executor can be passed directly to `with_defer`:
 
 ```ruby
 def call(env)
-  with_defer(executor: :fast) { @app.(env) }
+  with_defer(executor: :fast) { @app.call(env) }
 end
 ```
 
@@ -85,7 +85,7 @@ class HandleDefer
   end
 
   def call(env)
-    with_defer(executor: executor) { @app.(env) }
+    with_defer(executor: executor) { @app.call(env) }
   end
 
   def executor
@@ -103,7 +103,7 @@ class CreateUser
   def call(values)
     user_repo.transaction do
       user = user_repo.create(values)
-      defer { send_invitation.(user) }
+      defer { send_invitation.call(user) }
       user_account = account_repo.create(user)
       user
     end
@@ -116,13 +116,13 @@ There is no guarantee `send_invitation` will be run _after_ the transaction fini
 `later` captures the block but doesn't run it:
 
 ```ruby
-later { send_invitation.(user) }
+later { send_invitation.call(user) }
 ```
 
 The invitaition will be sent when `with_defer` exits:
 
 ```ruby
-with_defer { @app.(env) }
+with_defer { @app.call(env) }
 ```
 
 It usually happens outside of any transaction so that anomalies don't occur.

--- a/content/guides/dry/dry-effects/v0.5/effects/env.md
+++ b/content/guides/dry/dry-effects/v0.5/effects/env.md
@@ -17,7 +17,7 @@ class EnvironmentMiddleware
   end
 
   def call(env)
-    with_env { @app.(env) }
+    with_env { @app.call(env) }
   end
 end
 ```
@@ -97,7 +97,7 @@ RSpec.describe SendRequest do
   around { with_env('THIRD_PARTY' => endpoint, &ex) }
 
   it 'sends a request to a fake server' do
-    send_request.(...)
+    send_request.call(...)
   end
 end
 ```
@@ -135,7 +135,7 @@ overriding = OverridingContext.new
 providing = ProvidingContext.new
 app = Application.new
 
-overriding.() { providing.() { app.() } }
+overriding.call() { providing.call() { app.call() } }
 # prints 200, coming from overriding context
 ```
 

--- a/content/guides/dry/dry-effects/v0.5/effects/interrupt.md
+++ b/content/guides/dry/dry-effects/v0.5/effects/interrupt.md
@@ -42,10 +42,10 @@ end
 run = RunDivision.new
 divide = Divide.new
 
-app = -> a, b { run.() { divide.(a, b) } }
+app = -> a, b { run.call() { divide.call(a, b) } }
 
-app.(10, 2) # => 5
-app.(1, 0) # => :error
+app.call(10, 2) # => 5
+app.call(1, 0) # => :error
 ```
 
 The handler returns a flag indicating whether there was an interruption. `false` means the block was run without interruption, `true` stands for the code was interrupted at some point.
@@ -79,8 +79,8 @@ end
 caller = Caller.new
 callee = Callee.new
 
-caller.() { callee.() } # => :foo
-caller.() { } # => :bar
+caller.call() { callee.call() } # => :foo
+caller.call() { } # => :bar
 ```
 
 ### Composition

--- a/content/guides/dry/dry-effects/v0.5/effects/parallel.md
+++ b/content/guides/dry/dry-effects/v0.5/effects/parallel.md
@@ -15,7 +15,7 @@ class MakeRequests
 
   def call(urls)
     # Run every request in parallel and combine their results
-    urls.map { |url| par { make_request.(url) } }.then { |pars| join(pars) }
+    urls.map { |url| par { make_request.call(url) } }.then { |pars| join(pars) }
   end
 end
 ```

--- a/content/guides/dry/dry-effects/v0.5/effects/reader.md
+++ b/content/guides/dry/dry-effects/v0.5/effects/reader.md
@@ -16,7 +16,7 @@ class SetLocaleMiddleware
 
   def call(env)
     with_locale(detect_locale(env)) do
-      @app.(env)
+      @app.call(env)
     end
   end
 
@@ -63,7 +63,7 @@ RSpec.describe GreetUser do
 
     examples.each do |locale, expected_greeting|
       with_locale(locale) do
-        expect(greet.(user)).to eql(expected_greeting)
+        expect(greet.call(user)).to eql(expected_greeting)
       end
     end
   end
@@ -80,7 +80,7 @@ locale_provider = Object.new.extend(Dry::Effects::Handler.Reader(:locale, as: :c
 
 RSpec.configure do |config|
   config.around(:each) do |ex|
-    locale_provider.(:en, &ex)
+    locale_provider.call(:en, &ex)
   end
 end
 ```

--- a/content/guides/dry/dry-effects/v0.5/effects/resolve.md
+++ b/content/guides/dry/dry-effects/v0.5/effects/resolve.md
@@ -35,7 +35,7 @@ RSpec.describe CreateUser do
       name: 'John Doe'
     )
 
-    provide(user_repo: user_repo) { create_user.(first_name: 'John', last_name: 'Doe') }
+    provide(user_repo: user_repo) { create_user.call(first_name: 'John', last_name: 'Doe') }
   end
 end
 ```
@@ -52,7 +52,7 @@ class ProviderMiddleware
   end
 
   def call(env)
-    provide(@dependencies) { @app.(env) }
+    provide(@dependencies) { @app.call(env) }
   end
 end
 ```
@@ -73,7 +73,7 @@ Any object that responds to `.key?` and `.[]` can be used for providing dependen
 ```ruby
 def call(env)
   # Assuming App is a subclass of Dry::System::Container
-  provide(App) { @app.(env) }
+  provide(App) { @app.call(env) }
 end
 ```
 
@@ -91,7 +91,7 @@ class ProviderMiddleware
 
   def call(env)
     # Here Application will be used for resolving dependencies
-    provide { @app.(env) }
+    provide { @app.call(env) }
   end
 end
 ```
@@ -112,7 +112,7 @@ class CreateUser
   )
 
   def call(values)
-    result = schema.(values)
+    result = schema.call(values)
 
     if result.success?
       user = repo.create(result.to_h)
@@ -139,7 +139,7 @@ class ProviderMiddleware
   end
 
   def call(env)
-    provide(Application, overridable: overridable?) { @app.(env) }
+    provide(Application, overridable: overridable?) { @app.call(env) }
   end
 
   def overridable?

--- a/content/guides/dry/dry-effects/v0.5/effects/state.md
+++ b/content/guides/dry/dry-effects/v0.5/effects/state.md
@@ -47,7 +47,7 @@ Now it's simple to count calls by gluing two pieces:
 count_calls = CountCalls.new
 heavy_lifting = HeavyLifting.new
 
-count_calls.() { 1000.times { heavy_lifting.() }; :done }
+count_calls.call() { 1000.times { heavy_lifting.call() }; :done }
 # Counter: 1000
 # => :done
 ```
@@ -153,7 +153,7 @@ RSpec.describe AddingSomeMiddleware do
   subject(:middleware) { described_class.new(app) }
 
   it 'adds SOME_KEY to env' do
-    captured_env, _ = middleware.({})
+    captured_env, _ = middleware.call({})
 
     expect(captured_env).to have_key('SOME_KEY')
   end

--- a/content/guides/dry/dry-effects/v0.5/effects/timeout.md
+++ b/content/guides/dry/dry-effects/v0.5/effects/timeout.md
@@ -32,11 +32,11 @@ class WithTimeout
   end
 
   def call(env)
-    with_timeout(10.0) { @app.(env) }
+    with_timeout(10.0) { @app.call(env) }
   rescue Net::OpenTimeout, Net::ReadTimeout, Net::WriteTimeout
     [504, {}, ["Gateway Timeout"]]
   end
 end
 ```
 
-The code above guarantees all requests made with `MakeRequest` during `@app.(env)` will finish within 10 seconds. If `@app` doesn't spend much time somewhere else, it gives a reasonably reliable hard limit on request processing.
+The code above guarantees all requests made with `MakeRequest` during `@app.call(env)` will finish within 10 seconds. If `@app` doesn't spend much time somewhere else, it gives a reasonably reliable hard limit on request processing.

--- a/content/guides/dry/dry-logic/v1.6/_index.md
+++ b/content/guides/dry/dry-logic/v1.6/_index.md
@@ -33,18 +33,18 @@ has_min_age = Operations::Key.new(min_18, name: [:user, :age])
 
 user_rule = user_present & has_min_age
 
-user_rule.(user: { age: 19 }).success?
+user_rule.call(user: { age: 19 }).success?
 # => true
 
-user_rule.(user: { age: 18 }).success?
+user_rule.call(user: { age: 18 }).success?
 # => false
 
-user_rule.(user: { age: 'seventeen' })
+user_rule.call(user: { age: 'seventeen' })
 # => ArgumentError: comparison of String with 18 failed
 
-user_rule.(user: { })
+user_rule.call(user: { })
 # => NoMethodError: undefined method `>' for nil:NilClass
 
-user_rule.({}).success?
+user_rule.call({}).success?
 # => false
 ```

--- a/content/guides/dry/dry-logic/v1.6/operations.md
+++ b/content/guides/dry/dry-logic/v1.6/operations.md
@@ -21,7 +21,7 @@ has_min_age = Operations::Key.new(min_18, name: [:user, :age])
 # Thanks to the composable structure of the library we can use multiple Rules and Operations to create custom logic
 user_rule = user_present & has_min_age
 
-user_rule.(user: { age: 19 }).success?
+user_rule.call(user: { age: 19 }).success?
 # => true
 ```
 
@@ -52,12 +52,12 @@ end
 
 all_6 = all?(6)
 
-all_6.([7,8,9]).success?
+all_6.call([7,8,9]).success?
 # => true
 
-all_6.([6,7,8,9]).success?
+all_6.call([6,7,8,9]).success?
 # => false
 
-all_6.([1,2,3,4]).success?
+all_6.call([1,2,3,4]).success?
 # => false
 ```

--- a/content/guides/dry/dry-logic/v1.6/predicates.md
+++ b/content/guides/dry/dry-logic/v1.6/predicates.md
@@ -21,7 +21,7 @@ Predicates[:key?]
 In the end predicates return true or false.
 
 ```ruby
-Predicates[:key?].(:name, {name: 'John'})
+Predicates[:key?].call(:name, {name: 'John'})
 # => true
 ```
 
@@ -90,12 +90,12 @@ name_key = Rule::Predicate.new(Predicates[:key?]).curry(:name)
 hash_with_key = is_hash & name_key
 # => #<Dry::Logic::Operations::And rules=[#<Dry::Logic::Rule::Predicate predicate=#<Method: Module(Dry::Logic::Predicates::Methods)#type?> options={:args=>[:hash]}>, #<Dry::Logic::Rule::Predicate predicate=#<Method: Module(Dry::Logic::Predicates::Methods)#key?> options={:args=>[:name]}>] options={}>
 
-hash_with_key.(name: 'John').success?
+hash_with_key.call(name: 'John').success?
 # => true
 
-hash_with_key.(not_valid: 'John').success?
+hash_with_key.call(not_valid: 'John').success?
 # => false
 
-hash_with_key.([1,2]).success?
+hash_with_key.call([1,2]).success?
 # => false
 ```

--- a/content/guides/dry/dry-matcher/v1.0/_index.md
+++ b/content/guides/dry/dry-matcher/v1.0/_index.md
@@ -44,7 +44,7 @@ Then use these cases as part of an API to match on results:
 ```ruby
 my_success = [:ok, "success!"]
 
-result = matcher.(my_success) do |m|
+result = matcher.call(my_success) do |m|
   m.success do |v|
     "Yay: #{v}"
   end
@@ -67,7 +67,7 @@ Cases are executed in order. The first match wins and halts subsequent matching.
 ```ruby
 my_failure = [:err, :not_found, "missing!"]
 
-result = matcher.(my_failure) do |m|
+result = matcher.call(my_failure) do |m|
   m.success do |v|
     "Yay: #{v}"
   end

--- a/content/guides/dry/dry-matcher/v1.0/class-enhancement.md
+++ b/content/guides/dry/dry-matcher/v1.0/class-enhancement.md
@@ -22,7 +22,7 @@ end
 # And now `MyOperation#call` offers the matcher block API
 operation = MyOperation.new
 
-operation.() do |m|
+operation.call() do |m|
   # Use the matcher's API here
 end
 ```

--- a/content/guides/dry/dry-matcher/v1.0/maybe-matcher.md
+++ b/content/guides/dry/dry-matcher/v1.0/maybe-matcher.md
@@ -10,7 +10,7 @@ require "dry/matcher/maybe_matcher"
 
 value = Dry::Monads::Maybe("success!")
 
-result = Dry::Matcher::MaybeMatcher.(value) do |m|
+result = Dry::Matcher::MaybeMatcher.call(value) do |m|
   m.some(Integer) do |i|
     "Got int: #{i}"
   end

--- a/content/guides/dry/dry-matcher/v1.0/result-matcher.md
+++ b/content/guides/dry/dry-matcher/v1.0/result-matcher.md
@@ -10,7 +10,7 @@ require "dry/matcher/result_matcher"
 
 value = Dry::Monads::Success("success!")
 
-result = Dry::Matcher::ResultMatcher.(value) do |m|
+result = Dry::Matcher::ResultMatcher.call(value) do |m|
   m.success(Integer) do |i|
     "Got int: #{i}"
   end

--- a/content/guides/dry/dry-monads/v1.8/do-notation.md
+++ b/content/guides/dry/dry-monads/v1.8/do-notation.md
@@ -173,7 +173,7 @@ require 'dry/monads/do'
 require 'dry/monads/result'
 
 # some random place in your code
-Dry::Monads::Do.() do
+Dry::Monads::Do.call() do
   user = Dry::Monads::Do.bind create_user
   account = Dry::Monads::Do.bind create_account(user)
 
@@ -217,5 +217,5 @@ class SomeClassLevelLogic
   end
 end
 
-SomeClassLevelLogic.() # => Success(100)
+SomeClassLevelLogic.call() # => Success(100)
 ```

--- a/content/guides/dry/dry-monads/v1.8/result.md
+++ b/content/guides/dry/dry-monads/v1.8/result.md
@@ -50,7 +50,7 @@ class AssociateUser
   end
 end
 
-AssociateUser.new.(user_id: 1, address_id: 2)
+AssociateUser.new.call(user_id: 1, address_id: 2)
 ```
 
 ### `fmap`

--- a/content/guides/dry/dry-monads/v1.8/tracing-failures.md
+++ b/content/guides/dry/dry-monads/v1.8/tracing-failures.md
@@ -23,8 +23,8 @@ end
 require 'create_user'
 
 create_user = CreateUser.new
-create_user.()       # => Failure(:no_luck)
-create_user.().trace # => .../create_user.rb:8:in `call'
+create_user.call()       # => Failure(:no_luck)
+create_user.call().trace # => .../create_user.rb:8:in `call'
 ```
 
 Note that the trace stores only one line of the stack so it shouldn't ever be a performance issue.

--- a/content/guides/dry/dry-monads/v1.8/validated.md
+++ b/content/guides/dry/dry-monads/v1.8/validated.md
@@ -81,6 +81,6 @@ end
 Here all validations will be processed at once, if any of them fails the result will be converted to a `Failure` wrapping the `List` of errors:
 
 ```ruby
-create_account.(form)
+create_account.call(form)
 # => Failure(List[:invalid_name, :invalid_email])
 ```

--- a/content/guides/dry/dry-operation/v1.0/_index.md
+++ b/content/guides/dry/dry-operation/v1.0/_index.md
@@ -95,7 +95,7 @@ end
 After calling an operation, you will receive either a `Success` or a `Failure`. You can pattern match on this result to handle each situation:
 
 ```ruby
-case CreateUser.new.(input)
+case CreateUser.new.call(input)
 in Success[user]
   puts "User #{user.name} created successfully"
 in Failure[:invalid_input, errors]

--- a/content/guides/dry/dry-operation/v1.1/_index.md
+++ b/content/guides/dry/dry-operation/v1.1/_index.md
@@ -95,7 +95,7 @@ end
 After calling an operation, you will receive either a `Success` or a `Failure`. You can pattern match on this result to handle each situation:
 
 ```ruby
-case CreateUser.new.(input)
+case CreateUser.new.call(input)
 in Success[user]
   puts "User #{user.name} created successfully"
 in Failure[:invalid_input, errors]

--- a/content/guides/dry/dry-rails/v0.7/_index.md
+++ b/content/guides/dry/dry-rails/v0.7/_index.md
@@ -180,7 +180,7 @@ Here's a simple usage example how you could access an operation powered by dry-m
 ```ruby
 class UsersController < ApplicationController
   def create
-    resolve("users.create").(safe_params[:user]) do |m|
+    resolve("users.create").call(safe_params[:user]) do |m|
       m.success do |user|
         render json: user
       end

--- a/content/guides/dry/dry-schema/v1.14/_index.md
+++ b/content/guides/dry/dry-schema/v1.14/_index.md
@@ -83,7 +83,7 @@ UserSchema = Dry::Schema.Params do
   end
 end
 
-UserSchema.(
+UserSchema.call(
   name: 'Jane',
   email: 'jane@doe.org',
   address: { street: 'Street 1', city: 'NYC', zipcode: '1234' }

--- a/content/guides/dry/dry-schema/v1.14/advanced/composing-schemas.md
+++ b/content/guides/dry/dry-schema/v1.14/advanced/composing-schemas.md
@@ -32,13 +32,13 @@ User = Dry::Schema.JSON do
   required(:role).hash(Role & Expirable)
 end
 
-puts User.(name: "Jane", role: { id: "admin", expires_on: "2020-05-01" }).errors.to_h.inspect
+puts User.call(name: "Jane", role: { id: "admin", expires_on: "2020-05-01" }).errors.to_h.inspect
 # {}
 
-puts User.(name: "Jane", role: { id: "", expires_on: "2020-05-01" }).errors.to_h.inspect
+puts User.call(name: "Jane", role: { id: "", expires_on: "2020-05-01" }).errors.to_h.inspect
 # {role: {id: ["must be filled"]}}
 
-puts User.(name: "Jane", role: { id: "admin", expires_on: "oops" }).errors.to_h.inspect
+puts User.call(name: "Jane", role: { id: "admin", expires_on: "oops" }).errors.to_h.inspect
 # {role: {expires_on: ["must be a date"]}}
 ```
 
@@ -60,15 +60,15 @@ User = Dry::Schema.JSON do
   required(:role).hash(RoleID | RoleTitle)
 end
 
-puts User.(name: "Jane", role: {id: "admin"}).errors.to_h.inspect
+puts User.call(name: "Jane", role: {id: "admin"}).errors.to_h.inspect
 # {}
 
-puts User.(name: "Jane", role: {title: "Admin"}).errors.to_h.inspect
+puts User.call(name: "Jane", role: {title: "Admin"}).errors.to_h.inspect
 
-puts User.(name: "Jane", role: { id: ""}).errors.to_h.inspect
+puts User.call(name: "Jane", role: { id: ""}).errors.to_h.inspect
 # {:role=>{:or=>[{:id=>["must be filled"]}, {:title=>["is missing"]}]}}
 
-puts User.(name: "Jane", role: { title: ""}).errors.to_h.inspect
+puts User.call(name: "Jane", role: { title: ""}).errors.to_h.inspect
 # {:role=>{:or=>[{:id=>["is missing"]}, {:title=>["must be filled"]}]}}
 ```
 
@@ -90,15 +90,15 @@ User = Dry::Schema.JSON do
   required(:role).hash(RoleID > RoleTitle)
 end
 
-puts User.(name: "Jane", role: {id: "admin", title: "Admin"}).errors.to_h.inspect
+puts User.call(name: "Jane", role: {id: "admin", title: "Admin"}).errors.to_h.inspect
 # {}
 
-puts User.(name: "Jane", role: { id: ""}).errors.to_h.inspect
+puts User.call(name: "Jane", role: { id: ""}).errors.to_h.inspect
 # {}
 
-puts User.(name: "Jane", role: {title: "Admin"}).errors.to_h.inspect
+puts User.call(name: "Jane", role: {title: "Admin"}).errors.to_h.inspect
 # {}
 
-puts User.(name: "Jane", role: { id: "admin", title: ""}).errors.to_h.inspect
+puts User.call(name: "Jane", role: { id: "admin", title: ""}).errors.to_h.inspect
 # {:role=>{:title=>["must be filled"]}}
 ```

--- a/content/guides/dry/dry-schema/v1.14/advanced/processor-steps.md
+++ b/content/guides/dry/dry-schema/v1.14/advanced/processor-steps.md
@@ -29,6 +29,6 @@ end
 Now when the schema is applied, it'll remove all keys with `nil` values before coercions and rules are applied:
 
 ```ruby
-schema.(name: "Jane", age: nil)
+schema.call(name: "Jane", age: nil)
 # => #<Dry::Schema::Result{:name=>"jane"} errors={}>
 ```

--- a/content/guides/dry/dry-schema/v1.14/advanced/unexpected-keys.md
+++ b/content/guides/dry/dry-schema/v1.14/advanced/unexpected-keys.md
@@ -46,7 +46,7 @@ input = {
   roles: [{ name: 'admin' }, { name: 'editor', foo: 'unexpected' }]
 }
 
-UserSchema.(input).errors.to_h
+UserSchema.call(input).errors.to_h
 # {
 #  :foo=>["is not allowed"],
 #  :address=>{:bar=>["is not allowed"]},

--- a/content/guides/dry/dry-schema/v1.14/extensions/monads.md
+++ b/content/guides/dry/dry-schema/v1.14/extensions/monads.md
@@ -21,7 +21,7 @@ schema.call(name: 'Jane').to_monad # => Dry::Monads::Success(#<Dry::Schema::Resu
 
 schema.call(name: '').to_monad     # => Dry::Monads::Failure(#<Dry::Schema::Result{:name=>""} errors={:name=>["must be filled"]}>)
 
-schema.(name: "")
+schema.call(name: "")
   .to_monad
   .fmap { |r| puts "passed: #{r.to_h.inspect}" }
   .or   { |r| puts "failed: #{r.errors.to_h.inspect}" }
@@ -45,7 +45,7 @@ class Example
   Schema = Dry::Schema.Params { required(:name).filled(:string, size?: 2..4) }
 
   def call(input)
-    case schema.(input).to_monad
+    case schema.call(input).to_monad
     in Success(name:)
       "Hello #{name}" # name is captured from result
     in Failure(name:)
@@ -56,6 +56,6 @@ end
 
 run = Example.new
 
-run.('name' => 'Jane')   # => "Hello Jane"
-run.('name' => 'Albert') # => "Albert is not a valid name"
+run.call('name' => 'Jane')   # => "Hello Jane"
+run.call('name' => 'Albert') # => "Albert is not a valid name"
 ```

--- a/content/guides/dry/dry-schema/v1.14/nested-data.md
+++ b/content/guides/dry/dry-schema/v1.14/nested-data.md
@@ -62,7 +62,7 @@ schema = Dry::Schema.Params do
   end
 end
 
-schema.(address: nil).success? # true
+schema.call(address: nil).success? # true
 ```
 
 ### Nested `Array`

--- a/content/guides/dry/dry-schema/v1.14/reusing-schemas.md
+++ b/content/guides/dry/dry-schema/v1.14/reusing-schemas.md
@@ -17,7 +17,7 @@ UserSchema = Dry::Schema.Params do
   required(:address).hash(AddressSchema)
 end
 
-UserSchema.(
+UserSchema.call(
   email: 'jane@doe',
   name: 'Jane',
   address: { street: nil, city: 'NYC', zipcode: '123' }

--- a/content/guides/dry/dry-transaction/v0.16/around-steps.md
+++ b/content/guides/dry/dry-transaction/v0.16/around-steps.md
@@ -19,7 +19,7 @@ class MyContainer
 
     begin
       MyDB.transaction do
-        result = block.(Success(input))
+        result = block.call(Success(input))
         raise MyDB::Rollback if result.failure?
         result
       end

--- a/content/guides/dry/dry-transformer/v1.1/built-in-transformations.md
+++ b/content/guides/dry/dry-transformer/v1.1/built-in-transformations.md
@@ -27,7 +27,7 @@ module T
   import Dry::Transformer::Recursion
 end
 
-T[:to_string].(:abc) # => 'abc'
+T[:to_string].call(:abc) # => 'abc'
 ```
 
 Or import selectively with:
@@ -39,7 +39,7 @@ module T
   import :to_string, from: Dry::Transformer::Coercions, as: :stringify
 end
 
-T[:stringify].(:abc) # => 'abc'
-T[:to_string].(:abc)
+T[:stringify].call(:abc) # => 'abc'
+T[:to_string].call(:abc)
 # => Dry::Transformer::FunctionNotFoundError: No registered function T[:to_string]
 ```

--- a/content/guides/dry/dry-transformer/v1.1/transformation-objects.md
+++ b/content/guides/dry/dry-transformer/v1.1/transformation-objects.md
@@ -20,7 +20,7 @@ end
 
 mapper = MyMapper.new
 
-mapper.(
+mapper.call(
   [
     { 'user_name' => 'Jane',
       'city' => 'NYC',

--- a/content/guides/dry/dry-types/v1.7/custom-type-builders.md
+++ b/content/guides/dry/dry-types/v1.7/custom-type-builders.md
@@ -17,6 +17,6 @@ Dry::Types.define_builder(:or) { |type, value| type.fallback(value) }
 
 source_type = Dry::Types['integer']
 type = source_type.or(0)
-type.(10) # => 10
-type.(:invalid) # => 0
+type.call(10) # => 10
+type.call(:invalid) # => 0
 ```

--- a/content/guides/dry/dry-types/v1.7/default-values.md
+++ b/content/guides/dry/dry-types/v1.7/default-values.md
@@ -49,9 +49,9 @@ CallableDateTime[]
 **Be careful:** types will return the **same instance** of the default value every time. This may cause problems if you mutate the returned value after receiving it:
 
 ```ruby
-default_0 = PostStatus.()
+default_0 = PostStatus.call()
 # => "draft"
-default_1 = PostStatus.()
+default_1 = PostStatus.call()
 # => "draft"
 
 # Both variables point to the same string:
@@ -60,7 +60,7 @@ default_0.object_id == default_1.object_id
 
 # Mutating the string will change the default value of type:
 default_0 << '_mutated'
-PostStatus.(nil)
+PostStatus.call(nil)
 # => "draft_mutated" # not "draft"
 ```
 
@@ -68,7 +68,7 @@ You can guard against these kind of errors by calling `freeze` when setting the 
 
 ```ruby
 PostStatus = Types::Params::String.default('draft'.freeze)
-default = PostStatus.()
+default = PostStatus.call()
 default << 'attempt to mutate default'
 # => RuntimeError: can't modify frozen string
 

--- a/content/guides/dry/dry-types/v1.7/fallbacks.md
+++ b/content/guides/dry/dry-types/v1.7/fallbacks.md
@@ -7,9 +7,9 @@ Fallback value will be returned when invalid input is provided:
 ```ruby
 type = Dry::Types['integer'].fallback(100)
 
-type.(99) # => 99
-type.('99') # => 100
-type.(:invalid) # => 100
+type.call(99) # => 99
+type.call('99') # => 100
+type.call(:invalid) # => 100
 ```
 
 Block syntax:
@@ -18,9 +18,9 @@ Block syntax:
 cnt = 0
 type = Dry::Types['integer'].fallback { cnt += 1 }
 
-type.(99) # => 99
-type.('99') # => 1
-type.(:invalid) # => 2
+type.call(99) # => 99
+type.call('99') # => 1
+type.call(:invalid) # => 2
 ```
 
 Fallbacks are different from default values because the latter are triggered on _missing_ input rather than invalid. They can be combined:
@@ -29,6 +29,6 @@ Fallbacks are different from default values because the latter are triggered on 
 schema = Dry::Types['hash'].schema(
   size: Dry::Types['integer'].fallback(50).default(100)
 )
-schema.({}) # => { size: 100 }
-schema.({ size: 'invalid' }) # => { size: 50 }
+schema.call({}) # => { size: 100 }
+schema.call({ size: 'invalid' }) # => { size: 50 }
 ```

--- a/content/guides/dry/dry-types/v1.8/custom-type-builders.md
+++ b/content/guides/dry/dry-types/v1.8/custom-type-builders.md
@@ -17,6 +17,6 @@ Dry::Types.define_builder(:or) { |type, value| type.fallback(value) }
 
 source_type = Dry::Types['integer']
 type = source_type.or(0)
-type.(10) # => 10
-type.(:invalid) # => 0
+type.call(10) # => 10
+type.call(:invalid) # => 0
 ```

--- a/content/guides/dry/dry-types/v1.8/default-values.md
+++ b/content/guides/dry/dry-types/v1.8/default-values.md
@@ -49,9 +49,9 @@ CallableDateTime[]
 **Be careful:** types will return the **same instance** of the default value every time. This may cause problems if you mutate the returned value after receiving it:
 
 ```ruby
-default_0 = PostStatus.()
+default_0 = PostStatus.call()
 # => "draft"
-default_1 = PostStatus.()
+default_1 = PostStatus.call()
 # => "draft"
 
 # Both variables point to the same string:
@@ -60,7 +60,7 @@ default_0.object_id == default_1.object_id
 
 # Mutating the string will change the default value of type:
 default_0 << '_mutated'
-PostStatus.(nil)
+PostStatus.call(nil)
 # => "draft_mutated" # not "draft"
 ```
 
@@ -68,7 +68,7 @@ You can guard against these kind of errors by calling `freeze` when setting the 
 
 ```ruby
 PostStatus = Types::Params::String.default('draft'.freeze)
-default = PostStatus.()
+default = PostStatus.call()
 default << 'attempt to mutate default'
 # => RuntimeError: can't modify frozen string
 

--- a/content/guides/dry/dry-types/v1.8/fallbacks.md
+++ b/content/guides/dry/dry-types/v1.8/fallbacks.md
@@ -7,9 +7,9 @@ Fallback value will be returned when invalid input is provided:
 ```ruby
 type = Dry::Types['integer'].fallback(100)
 
-type.(99) # => 99
-type.('99') # => 100
-type.(:invalid) # => 100
+type.call(99) # => 99
+type.call('99') # => 100
+type.call(:invalid) # => 100
 ```
 
 Block syntax:
@@ -18,9 +18,9 @@ Block syntax:
 cnt = 0
 type = Dry::Types['integer'].fallback { cnt += 1 }
 
-type.(99) # => 99
-type.('99') # => 1
-type.(:invalid) # => 2
+type.call(99) # => 99
+type.call('99') # => 1
+type.call(:invalid) # => 2
 ```
 
 Fallbacks are different from default values because the latter are triggered on _missing_ input rather than invalid. They can be combined:
@@ -29,6 +29,6 @@ Fallbacks are different from default values because the latter are triggered on 
 schema = Dry::Types['hash'].schema(
   size: Dry::Types['integer'].fallback(50).default(100)
 )
-schema.({}) # => { size: 100 }
-schema.({ size: 'invalid' }) # => { size: 50 }
+schema.call({}) # => { size: 100 }
+schema.call({ size: 'invalid' }) # => { size: 50 }
 ```

--- a/content/guides/dry/dry-validation/v1.11/extensions.md
+++ b/content/guides/dry/dry-validation/v1.11/extensions.md
@@ -25,7 +25,7 @@ end
 
 my_contract = MyContract.new
 
-my_contract.(name: "")
+my_contract.call(name: "")
   .to_monad
   .fmap { |r| puts "passed: #{r.to_h.inspect}" }
   .or   { |r| puts "failed: #{r.errors.to_h.inspect}" }
@@ -54,7 +54,7 @@ class AgeContract < ApplicationContract
   rule(:age).validate(gteq?: 18)
 end
 
-AgeContract.new.(age: 17).errors.first.text
+AgeContract.new.call(age: 17).errors.first.text
 # => 'must be greater than or equal to 18'
 ```
 

--- a/content/guides/dry/dry-validation/v1.11/pattern-matching.md
+++ b/content/guides/dry/dry-validation/v1.11/pattern-matching.md
@@ -14,7 +14,7 @@ end
 
 contract = PersonContract.new
 
-case contract.('first_name' => 'John', 'last_name' => 'Doe')
+case contract.call('first_name' => 'John', 'last_name' => 'Doe')
 in { first_name:, last_name: } => result if result.success?
   puts "Hello #{first_name} #{last_name}"
 in _ => result
@@ -40,7 +40,7 @@ end
 
 contract = AddressContract.new(address_repo: AddressRepo.new)
 
-case contract.('name' => 'John Doe', 'address' => 'Pedro Moreno 10, Ciudad de México')
+case contract.call('name' => 'John Doe', 'address' => 'Pedro Moreno 10, Ciudad de México')
 in [{ name: }, { address: }] => result if result.success?
   # adding person to existing address
 in { name:, address: } => result if result.success?
@@ -77,7 +77,7 @@ class CreatePerson
   end
 
   def call(input)
-    case contract.(input).to_monad
+    case contract.call(input).to_monad
     in Success(first_name:, last_name:)
       Success(repo.create(first_name, last_name))
     in Failure(result)

--- a/content/guides/dry/dry-validation/v1.11/rules.md
+++ b/content/guides/dry/dry-validation/v1.11/rules.md
@@ -214,7 +214,7 @@ class PersonContract < Dry::Validation::Contract
   end
 end
 
-PersonContract.new.(email: nil, name: 'foo').errors.to_h
+PersonContract.new.call(email: nil, name: 'foo').errors.to_h
 # { email: ['must be a string'], name: ['first introduce a valid email'] }
 ```
 
@@ -232,7 +232,7 @@ class FooContract < Dry::Validation::Contract
   end
 end
 
-FooContract.new.(foo: 'foo').errors.to_h
+FooContract.new.call(foo: 'foo').errors.to_h
 # { foo: ['failure added', 'failure added after checking'] }
 ```
 

--- a/content/guides/dry/dry-validation/v1.11/schemas.md
+++ b/content/guides/dry/dry-validation/v1.11/schemas.md
@@ -108,7 +108,7 @@ end
 
 contract = NewUserContract.new
 
-contract.(name: "Jane", age: "31", email: "jane@doe.org", country: "foo")
+contract.call(name: "Jane", age: "31", email: "jane@doe.org", country: "foo")
 # => #<Dry::Validation::Result{:name=>"Jane", :age=>31, :email=>"jane@doe.org",
 #   :country=>"foo"} errors={:zipcode=>["is missing"], :street=>["is missing"],
 #   :mobile=>["is missing"]}>

--- a/content/posts/2016/2016-03-16-announcing-dry-rb.md
+++ b/content/posts/2016/2016-03-16-announcing-dry-rb.md
@@ -47,7 +47,7 @@ UserSchema = Dry::Validation.Schema do
   end
 end
 
-UserSchema.(
+UserSchema.call(
   email: 'jane@doe.org',
   age: 21,
   address: {

--- a/content/posts/2016/2016-03-31-new-releases-of-dry-types-and-dry-validation.md
+++ b/content/posts/2016/2016-03-31-new-releases-of-dry-types-and-dry-validation.md
@@ -28,7 +28,7 @@ UserSchema = Dry::Validation.Form do
   key(:age).required(Types::Age)
 end
 
-UserSchema.(name: 'Jane', age: 17).messages
+UserSchema.call(name: 'Jane', age: 17).messages
 # { age: ["must be greater than 18"] }
 ```
 
@@ -61,7 +61,7 @@ UserImport = Dry::Validation.Schema do
   key(:email).required(Types::DataImport::StrippedString)
 end
 
-UserSchema.(name: '   Jane  ', email: 'jane@doe.org  ').to_h
+UserSchema.call(name: '   Jane  ', email: 'jane@doe.org  ').to_h
 # { name: "Jane", email: "jane@doe.org" }
 ```
 
@@ -70,7 +70,7 @@ This is a clean way of encapsulating custom coercion or sanitization logic. Noti
 dry-validation infers both validation rules and value constructors from your types, notice that `Types::DataImport::StrippedString` is a strict string, which means a proper validation rule is set too:
 
 ```ruby
-UserSchema.(name: '   Jane  ', email: nil).messages
+UserSchema.call(name: '   Jane  ', email: nil).messages
 # { email: ["must be filled", "must be String"] }
 ```
 
@@ -102,15 +102,15 @@ CommandSchema = Dry::Validation.Schema do
   end
 end
 
-CommandSchema.(command: 'Oops').messages.inspect
+CommandSchema.call(command: 'Oops').messages.inspect
 # { command: ["must be one of: Create, Update"], args: ["is missing"] }
 
-CommandSchema.(
+CommandSchema.call(
   command: 'Create', args: { name: 'Jane', email: nil }
 ).messages
 # { args: { email: ["must be filled"] } }
 
-CommandSchema.(
+CommandSchema.call(
   command: 'Update', args: { id: 1, data: { name: nil, email: 'jane@doe.org' } }
 ).messages
 # { data: { name: ["must be filled"] } }
@@ -127,13 +127,13 @@ UserSchema = Dry::Validation.Form do
   key(:age).required(:number?, :int?)
 end
 
-UserSchema.(age: '1').to_h
+UserSchema.call(age: '1').to_h
 # { age: 1 }
 
-UserSchema.(age: 'one').messages
+UserSchema.call(age: 'one').messages
 # { age: ["must be a number"] }
 
-UserSchema.(age: '1.5').messages
+UserSchema.call(age: '1.5').messages
 # { age: ["must be an integer"] }
 ```
 

--- a/content/posts/2016/2016-04-07-dry-transaction-0-6-brings-powerful-new-support-for-custom-step-adapters.md
+++ b/content/posts/2016/2016-04-07-dry-transaction-0-6-brings-powerful-new-support-for-custom-step-adapters.md
@@ -36,7 +36,7 @@ module Admin
       include Admin::Import("admin.enqueue_background_job")
 
       def call(step, *args, input)
-        enqueue_background_job.(step.operation_name, *args, input)
+        enqueue_background_job.call(step.operation_name, *args, input)
         Right(input)
       end
     end

--- a/content/posts/2016/2016-07-01-dry-validation-0-8-0-released.md
+++ b/content/posts/2016/2016-07-01-dry-validation-0-8-0-released.md
@@ -105,10 +105,10 @@ UserSchema = Dry::Validation.Schema do
   required(:login).filled(:str?, min_size?: 3)
 end
 
-UserSchema.(login: "").messages
+UserSchema.call(login: "").messages
 # {:login=>["must be filled", "please make sure it has at least 3 chars"]}
 
-UserSchema.(login: "fo").messages
+UserSchema.call(login: "fo").messages
 {:login=>["size can't be less than 3"]}
 ```
 
@@ -125,7 +125,7 @@ UserSchema = Dry::Validation.Schema do
   required(:name).filled(:str?)
 end
 
-UserSchema.(nil).messages # ["must be a hash"]
+UserSchema.call(nil).messages # ["must be a hash"]
 ```
 
 Notice that when a root-level rule fails, `messages` returns a flat array rather than a hash.
@@ -153,15 +153,15 @@ UserSchema = Dry::Validation.Schema do
   end
 end
 
-UserSchema.(name: "Jane", login_time: nil).messages
+UserSchema.call(name: "Jane", login_time: nil).messages
 # {}
 
 schema = UserSchema.with(current_user: { id: 1 })
 
-schema.(name: "Jane", login_time: DateTime.now).messages
+schema.call(name: "Jane", login_time: DateTime.now).messages
 # {}
 
-schema.(name: "Jane", login_time: nil).messages
+schema.call(name: "Jane", login_time: nil).messages
 # {:login_time=>["must be filled"]}
 ```
 
@@ -188,7 +188,7 @@ UserSchema = Dry::Validation.Schema do
   required(:data).value(source_valid?: "TADA")
 end
 
-UserSchema.(data: "w00t").messages
+UserSchema.call(data: "w00t").messages
 # {:data=>["my message has access to TADA and w00t :D"]}
 ```
 

--- a/content/posts/2016/2016-09-23-new-dry-rb-gem-releases.md
+++ b/content/posts/2016/2016-09-23-new-dry-rb-gem-releases.md
@@ -28,10 +28,10 @@ UserSchema = Dry::Validation.Form do
   required(:age).filled(:int?, gt?: 18)
 end
 
-UserSchema.(login: '', age: 17).errors
+UserSchema.call(login: '', age: 17).errors
 # {:login=>["must be filled"], :age=>["must be greater than 18"]}
 
-UserSchema.(login: '', age: 17).hints
+UserSchema.call(login: '', age: 17).hints
 # {:login=>["length must be within 3 - 64"], :age=>[]}
 ```
 
@@ -44,7 +44,7 @@ PostSchema = Dry::Validation.Form do
   required(:tags).filled { array? | str? }
 end
 
-PostSchema.(tags: 123).errors
+PostSchema.call(tags: 123).errors
 # {:tags=>["must be an array or must be a string"]}
 ```
 
@@ -73,7 +73,7 @@ end
 
 schema = UserSchema.with(ids: [1, 2, 3])
 
-schema.(id: 4).errors
+schema.call(id: 4).errors
 # {:valid_id=>["id is not valid"]}
 ```
 
@@ -89,11 +89,11 @@ UserSchema = Dry::Validation.Form do
   required(:age).filled(:int?, gt?: 18)
 end
 
-result = UserSchema.(login: '', age: 17).to_either
+result = UserSchema.call(login: '', age: 17).to_either
 result.fmap { |data| data[:login] }.or { 'oops' }.value
 # "oops"
 
-result = UserSchema.(login: 'jane', age: 19).to_either
+result = UserSchema.call(login: 'jane', age: 19).to_either
 result.fmap { |data| data[:login] }.or { 'oops' }.value
 # "jane"
 ```
@@ -169,11 +169,11 @@ Last but not least - the new version of dry-logic is not just few times faster, 
 age_rule = Dry::Logic.Rule { |v| !v.nil? }.then(
   Dry::Logic.Rule { |v| v.is_a?(Integer) }.and(Dry::Logic.Rule { |v| v > 18 }))
 
-age_rule.(nil).success?
+age_rule.call(nil).success?
 # true
-age_rule.(19).success?
+age_rule.call(19).success?
 # true
-age_rule.('19').success?
+age_rule.call('19').success?
 # false
 ```
 

--- a/content/posts/2017/2017-01-30-announcing-dry-view-a-functional-view-rendering-system-for-ruby.md
+++ b/content/posts/2017/2017-01-30-announcing-dry-view-a-functional-view-rendering-system-for-ruby.md
@@ -58,7 +58,7 @@ Then `#call` your view controller to render your view:
 
 ```ruby
 view = HelloView.new
-view.(greeting: "Hello from dry-rb!")
+view.call(greeting: "Hello from dry-rb!")
 # => "<html><body><h1>Hello!</h1><p>Hello from dry-rb!</p></body></html>
 ```
 

--- a/content/posts/2017/2017-06-15-dry-transaction-0-10-0-brings-class-based-transactions-and-a-whole-new-level-of-flexibility.md
+++ b/content/posts/2017/2017-06-15-dry-transaction-0-10-0-brings-class-based-transactions-and-a-whole-new-level-of-flexibility.md
@@ -20,7 +20,7 @@ class MyTransaction
 end
 
 my_trans = MyTransaction.new
-my_trans.(some_input)
+my_trans.call(some_input)
 ```
 
 Transactions may resolve their operations from containers as before, but they can also now work entirely with local methods ("look ma, no container!"):

--- a/content/posts/2018/2018-06-26-dry-monads-1-0-released.md
+++ b/content/posts/2018/2018-06-26-dry-monads-1-0-released.md
@@ -60,16 +60,16 @@ class DivideThenRoot
   end
 
   def call(x, y)
-    divide.(x, y).bind(sqrt)
+    divide.call(x, y).bind(sqrt)
   end
 end
 ```
 
 ```ruby
 op = DivideThenRoot.new
-op.(1.0, 2.0) # => Success(0.7071067811865476)
-op.(1.0, 0.0) # => Failure(:division_by_zero)
-op.(-1.0, 2.0) # => Failure(:negative_number)
+op.call(1.0, 2.0) # => Success(0.7071067811865476)
+op.call(1.0, 0.0) # => Failure(:division_by_zero)
+op.call(-1.0, 2.0) # => Failure(:negative_number)
 ```
 
 `DivideThenRoot` can be composed with other objects or methods returning `Result`s in a similar manner. In the end, you can use [`dry-matcher`](/learn/dry/dry-matcher/result-matcher) for processing the result (or use the `Result`'s [API](/learn/dry/dry-monads/result) for it).

--- a/content/posts/2019/2019-04-23-dry-types-and-dry-struct-1-0-0-released.md
+++ b/content/posts/2019/2019-04-23-dry-types-and-dry-struct-1-0-0-released.md
@@ -49,10 +49,10 @@ Previously it was only possible to append a constructor function. This was too l
 ```ruby
 to_int = Types::Coercible::Integer
 inc = to_int.append { |x| x + 2 }
-inc.("1") # => "1" -> 1 -> 3
+inc.call("1") # => "1" -> 1 -> 3
 
 inc = to_int.prepend { |x| x + "2" }
-inc.("1") # => "1" -> "12" -> 12
+inc.call("1") # => "1" -> "12" -> 12
 ```
 
 This feature should be very useful in places like rom-rb's schemas or dry-schema, where you may want to pre-process data and then re-use existing coercion logic.

--- a/content/posts/2019/2019-06-10-dry-validation-1-0-0-released.md
+++ b/content/posts/2019/2019-06-10-dry-validation-1-0-0-released.md
@@ -174,7 +174,7 @@ Now let's see it in action:
 ```ruby
 contract = NewSongContract.new
 
-contract.(artist: "Queen", title: "Bohemian Rhapsody", tags: ["rock", 123, "ab"]).errors.to_h
+contract.call(artist: "Queen", title: "Bohemian Rhapsody", tags: ["rock", 123, "ab"]).errors.to_h
 # => {:tags=>{1=>["must be a string"], 2=>["tag length must be at least 3"]}
 ```
 

--- a/content/posts/2019/2019-10-03-introducing-dry-effects.md
+++ b/content/posts/2019/2019-10-03-introducing-dry-effects.md
@@ -52,7 +52,7 @@ class WithCurrentTime
   end
 
   def call(env)
-    with_current_time { @app.(env) }
+    with_current_time { @app.call(env) }
   end
 end
 ```
@@ -66,7 +66,7 @@ subject(:create_subscription) { CreateSubscription.new }
 
 example "creating subscription on New Year's Eve" do
   with_current_time(proc { Time.new(2019, 12, 31, 12) }) do
-    create_subscription.(...)
+    create_subscription.call(...)
   end
 end
 ```
@@ -124,7 +124,7 @@ let(:user_repo) { double(:user_repo, create: ...) }
 
 example 'creating a user' do
   provide(user_repo: user_repo) do
-    create_user.(...)
+    create_user.call(...)
   end
 end
 ```

--- a/content/posts/2020/2020-03-11-dry-schema-and-dry-validation-1-5-0-released.md
+++ b/content/posts/2020/2020-03-11-dry-schema-and-dry-validation-1-5-0-released.md
@@ -27,13 +27,13 @@ UserSchema = Dry::Schema.JSON do
   required(:role).hash(RoleSchema & ExpirableSchema)
 end
 
-UserSchema.(name: "Jane", role: { id: "admin", expires_on: "2020-05-01" }).errors.to_h
+UserSchema.call(name: "Jane", role: { id: "admin", expires_on: "2020-05-01" }).errors.to_h
 # {}
 
-UserSchema.(name: "Jane", role: { id: "", expires_on: "2020-05-01" }).errors.to_h
+UserSchema.call(name: "Jane", role: { id: "", expires_on: "2020-05-01" }).errors.to_h
 # {role: {id: ["must be filled"]}}
 
-UserSchema.(name: "Jane", role: { id: "admin", expires_on: "oops" }).errors.to_h
+UserSchema.call(name: "Jane", role: { id: "admin", expires_on: "oops" }).errors.to_h
 # {role: {expires_on: ["must be a date"]}}
 ```
 
@@ -67,7 +67,7 @@ input = {
   roles: [{ name: 'admin' }, { name: 'editor', foo: 'unexpected' }]
 }
 
-UserSchema.(input).errors.to_h
+UserSchema.call(input).errors.to_h
 # {
 #  :foo=>["is not allowed"],
 #  :address=>{:bar=>["is not allowed"]},


### PR DESCRIPTION
As many of us know, `.(…)` is short-hand for `.call(…)`. However, this isn't super well-known in the Ruby community and it can be distracting for people who don't know about it.

This PR changes all of those references across our guides and blog posts to `.call(…)`