### PR TITLE
dry-configurable - Add docs for #to_data and #finalize!

### DIFF
--- a/content/guides/dry/dry-configurable/v1.4/_index.md
+++ b/content/guides/dry/dry-configurable/v1.4/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction & Usage
 pages:
+  - to-data
   - testing
 ---
 
@@ -27,7 +28,9 @@ class App
   setting :adapter
   # Construct values
   setting :path, default: 'test', constructor: proc { |value| Pathname(value) }
-  # Passing the reader option as true will create attr_reader method for the class
+  # Passing the reader option as true will create attr_reader method for the class.
+  # Note: this defines the method on the class itself; see the "Converting config to Data"
+  # guide for #to_data, an alternative that keeps accessors on a separate Data object.
   setting :pool, default: 5, reader: true
   # Passing the reader attributes works with nested configuration
   setting :uploader, reader: true do
@@ -129,3 +132,30 @@ end
 client1.adapter # => :grpc
 client2.adapter # => :http
 ```
+
+#### Finalizing
+
+Once you're done configuring, call `finalize!` to lock the config against further changes. This is typically done at boot, after the application has read its settings from the environment, files, etc.
+
+```ruby
+App.configure do |config|
+  config.adapter = :grpc
+  config.pool = 5
+end
+
+App.config.finalize!
+
+App.config.adapter = :http
+# => raises Dry::Configurable::FrozenConfigError
+```
+
+`finalize!` freezes the config itself but leaves the values it holds mutable. Pass `freeze_values: true` to also freeze each value:
+
+```ruby
+App.config.finalize!(freeze_values: true)
+
+App.config.tags << "new"
+# => raises FrozenError
+```
+
+Finalizing is also a prerequisite for [`#to_data`](//page/to-data), which returns a frozen `Data` snapshot of the resolved values.

--- a/content/guides/dry/dry-configurable/v1.4/to-data.md
+++ b/content/guides/dry/dry-configurable/v1.4/to-data.md
@@ -45,8 +45,6 @@ class Renderer
 end
 ```
 
-If you cannot hold the `Data` on an instance, memoize it by the config's `object_id` so you reuse the same `Data` across calls for the same config.
-
 ### Comparison with `reader: true`
 
 The `reader: true` option on `setting` is another way to avoid the `method_missing` cost: it defines `attr_reader`-style methods directly on the configured object.

--- a/content/guides/dry/dry-configurable/v1.4/to-data.md
+++ b/content/guides/dry/dry-configurable/v1.4/to-data.md
@@ -1,0 +1,123 @@
+---
+title: Converting config to Data
+---
+
+### Overview
+
+`Config#to_data` returns a frozen [`Data`](https://docs.ruby-lang.org/en/4.0/Data.html) representation of the config's resolved values. It is intended for performance-sensitive code that reads the same config repeatedly, such as per-request rendering hot paths.
+
+```ruby
+class App
+  extend Dry::Configurable
+
+  setting :adapter, default: :http
+  setting :database do
+    setting :dsn, default: "sqlite:memory"
+  end
+end
+
+App.config.finalize!
+
+data = App.config.to_data
+data.adapter          # => :http
+data.database.dsn     # => "sqlite:memory"
+data.frozen?          # => true
+```
+
+Nested settings become nested `Data` instances, so the same dotted-access pattern you use on `config` works on the returned `Data`.
+
+### When to use it
+
+Reading a value through `config.foo` dispatches through `method_missing`. When the same config is read many times (e.g. once per request), going through `Data` accessors is significantly faster. You will only see this speedup if you cache the returned `Data`; calling `#to_data` allocates a fresh object every time.
+
+```ruby
+class Renderer
+  def initialize(config)
+    @config = config.to_data
+  end
+
+  attr_reader :config
+
+  def call(template)
+    # Reads like `config.adapter` now hit a Data accessor directly
+    # ...
+  end
+end
+```
+
+If you cannot hold the `Data` on an instance, memoize it by the config's `object_id` so you reuse the same `Data` across calls for the same config.
+
+### Comparison with `reader: true`
+
+The `reader: true` option on `setting` is another way to avoid the `method_missing` cost: it defines `attr_reader`-style methods directly on the configured object.
+
+```ruby
+class App
+  extend Dry::Configurable
+
+  setting :adapter, default: :http, reader: true
+end
+
+App.adapter # => :http, no method_missing
+```
+
+The tradeoff is that those readers live on the configured object itself. That means:
+
+- The configured class/module/instance grows a method for every reader setting, which can collide with existing methods or clutter its public surface.
+- For instance-level configurables, every instance carries the reader methods.
+- Readers can only be defined per setting up-front; you cannot opt a whole config block into reader access in one go.
+
+`#to_data` takes the opposite approach: the accessors live on a separate frozen `Data` object that you hold (and cache) yourself. The configured object stays untouched, you get accessors for every setting at every nesting level for free, and reads through the `Data` are typically faster than `reader:` methods because they go through `Data`'s built-in accessors rather than `dry-configurable`'s reader dispatch.
+
+Reach for `reader: true` when ergonomics on the configured object matter most. Reach for `#to_data` when you want a self-contained, frozen snapshot you can pass around (especially in hot paths).
+
+### Finalize before calling
+
+`#to_data` requires the config to be finalized (frozen). Calling it on a mutable config raises `Dry::Configurable::FrozenConfigError`.
+
+```ruby
+App.config.to_data
+# => raises Dry::Configurable::FrozenConfigError
+
+App.config.finalize!
+App.config.to_data
+# => #<data App adapter=:http, database=#<data ...>>
+```
+
+Finalizing matches the intended use case: once configuration is locked down at boot, the resulting `Data` is a stable, frozen snapshot.
+
+### Value capture semantics
+
+Values are captured by reference. Freezing the `Data` does not deep-freeze the values it holds, so in-place mutation of a captured value remains visible through the `Data`:
+
+```ruby
+class App
+  extend Dry::Configurable
+
+  setting :tags, default: ["a", "b"]
+end
+
+App.config.finalize!
+data = App.config.to_data
+
+App.config.tags << "c"
+data.tags # => ["a", "b", "c"]
+```
+
+If you need an immutable snapshot, freeze (or `dup.freeze`) the values themselves before finalizing.
+
+### Reserved setting names
+
+Because `#to_data` builds a `Data` class whose members are your setting names, a setting cannot share a name with an instance method on `Data` (such as `hash`, `members`, `to_h`, or `with`). Defining one raises `ArgumentError` at setting-definition time:
+
+```ruby
+class App
+  extend Dry::Configurable
+
+  setting :members
+  # => raises ArgumentError: setting name `:members` conflicts with a Data
+  #    instance method, which would break Config#to_data
+end
+```
+
+Pick a different name (e.g. `:member_list`) if you hit this.


### PR DESCRIPTION
For new feature from https://github.com/dry-rb/dry-configurable/pull/167 

I also added docs for #finalize! since that's necessary for using #to_data

[Preview link](https://pr-383--hanakai.netlify.app/learn/dry/dry-configurable/v1.4/to-data)