### PR TITLE
Fix code background on system dark theme and website light

### DIFF
--- a/app/assets/css/theme.css
+++ b/app/assets/css/theme.css
@@ -84,6 +84,13 @@
     --hk-color-text-link-active: var(--color-hanakai-200);
   }
 
+  html[data-theme-pref="light"] .theme-hanakai,
+  html[data-theme-pref="light"] .theme-hanami,
+  html[data-theme-pref="light"] .theme-dry,
+  html[data-theme-pref="light"] .theme-rom {
+    --hk-color-bg-secondary-subtle: oklch(from var(--color-rom-50) l c h / 0.4);
+  }
+
   .theme-hanakai,
   .theme-hanami,
   .theme-dry,


### PR DESCRIPTION
### Before

<img width="1683" height="959" alt="Screenshot_20260526_130505" src="https://github.com/user-attachments/assets/ddf53dfb-b7ce-4a69-84ff-0dfd234f583e" />

### After
<img width="1684" height="963" alt="Screenshot_20260526_131229" src="https://github.com/user-attachments/assets/4c8bf1b4-2f0f-48e6-ae41-4b8a71b9a63a" />

### Note
This happens because my system has dark theme, but I choose light theme for the website. In general, I'm not sure we should rely on `prefers-color-scheme`, as it might lead to more issue like that, but I don't know what's current state of things in frontend world for that.