### PR TITLE
Delete -> Destroy: fix code sample in web app guide

### DIFF
--- a/content/guides/hanami/v2.3/getting-started/building-a-web-app.md
+++ b/content/guides/hanami/v2.3/getting-started/building-a-web-app.md
@@ -869,7 +869,7 @@ In the action, we can now delete the existing book, set a flash message and redi
 module Bookshelf
   module Actions
     module Books
-      class Delete < Bookshelf::Action
+      class Destroy < Bookshelf::Action
         include Deps["repos.book_repo"]
 
         params do

--- a/content/guides/hanami/v3.0/getting-started/building-a-web-app.md
+++ b/content/guides/hanami/v3.0/getting-started/building-a-web-app.md
@@ -869,7 +869,7 @@ In the action, we can now delete the existing book, set a flash message and redi
 module Bookshelf
   module Actions
     module Books
-      class Delete < Bookshelf::Action
+      class Destroy < Bookshelf::Action
         include Deps["repos.book_repo"]
 
         params do


### PR DESCRIPTION
As noticed in https://discourse.hanakai.org/t/why-destroy-instead-of-delete/1458, the action class should be named `Destroy`, not `Delete` (and we agreed to keep it that way).