### PR TITLE
Restructure header anchors to avoid awkward CSS/layout

### DIFF
--- a/app/assets/css/content.css
+++ b/app/assets/css/content.css
@@ -45,12 +45,8 @@
   h3,
   h4,
   h5 {
-    display: flex;
-    align-items: center;
     line-height: var(--leading-tight);
-    gap: calc(var(--spacing));
     a[href^="#"] {
-      order: 2;
       margin-inline-start: calc(var(--spacing) * 2);
     }
     a[href^="#"]:before {
@@ -60,20 +56,6 @@
       font-family: var(--font-mono);
       font-weight: var(--font-weight-normal);
       position: static;
-    }
-  }
-
-  h1,
-  h2 {
-    a[href^="#"]:before {
-      margin-block-start: calc(var(--spacing) * 1.2);
-    }
-  }
-  h3,
-  h4,
-  h5 {
-    a[href^="#"]:before {
-      margin-block-start: calc(var(--spacing) * 0.6);
     }
   }
 

--- a/app/content/filters/move_heading_anchors_filter.rb
+++ b/app/content/filters/move_heading_anchors_filter.rb
@@ -1,0 +1,46 @@
+# auto_register: false
+# frozen_string_literal: true
+
+require "nokogiri"
+
+module Site
+  module Content
+    module Filters
+      # Repositions each heading's auto-generated anchor link.
+      #
+      # The default Markdown processor injects the permalink anchor (`<a class="anchor">`) as the
+      # heading’s first child, this anchor includes the `id` that "#slug" links target. This filter
+      # makes two adjustments:
+      #
+      # - Moves the anchor to the end of the heading, so the heading is a plain inline-flow block.
+      # - Moves the `id` from the anchor onto the heading, which is the semantically correct
+      #   fragment target and ensures screen-readers are properly located
+      #
+      # Repositioning needs whole-element awareness, so this runs as an output
+      # filter rather than a streaming NodeFilter (see InlineAttributeListFilter).
+      class MoveHeadingAnchorsFilter
+        HEADINGS = "h1, h2, h3, h4, h5, h6"
+
+        def call(html)
+          doc = Nokogiri::HTML::DocumentFragment.parse(html)
+
+          doc.css(HEADINGS).each do |heading|
+            anchor = heading.at_css("a.anchor")
+            next unless anchor
+
+            if (id = anchor["id"])
+              heading["id"] = id
+              anchor.remove_attribute("id")
+            end
+
+            # add_child moves an already-attached node, so this re-parents the
+            # anchor to the end of the heading.
+            heading.add_child(anchor)
+          end
+
+          doc.to_html
+        end
+      end
+    end
+  end
+end

--- a/app/content/output_filters.rb
+++ b/app/content/output_filters.rb
@@ -3,6 +3,7 @@
 
 require_relative "filters/emoji_logo_filter"
 require_relative "filters/inline_attribute_list_filter"
+require_relative "filters/move_heading_anchors_filter"
 require_relative "filters/namespace_constant_filter"
 
 module Site
@@ -13,6 +14,7 @@ module Site
     DEFAULT_OUTPUT_FILTERS = [
       Filters::EmojiLogoFilter.new,
       Filters::InlineAttributeListFilter.new,
+      Filters::MoveHeadingAnchorsFilter.new,
       Filters::NamespaceConstantFilter.new
     ].freeze
   end

--- a/spec/content/filters/move_heading_anchors_filter_spec.rb
+++ b/spec/content/filters/move_heading_anchors_filter_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "nokogiri"
+
+RSpec.describe Site::Content::Filters::MoveHeadingAnchorsFilter do
+  def call(html)
+    described_class.new.call(html)
+  end
+
+  # Compare on structure rather than the serialized string, since Nokogiri
+  # introduces insignificant whitespace text nodes that don't affect rendering.
+  def heading(html)
+    Nokogiri::HTML::DocumentFragment.parse(call(html)).at_css("h1, h2, h3, h4, h5, h6")
+  end
+
+  it "moves the heading's anchor link to the end of the heading" do
+    h = heading(%(<h2><a href="#title" class="anchor" id="title"></a>Title</h2>))
+
+    expect(h.element_children.last.name).to eq("a")
+    expect(h.element_children.last["href"]).to eq("#title")
+    expect(h.text.strip).to eq("Title")
+  end
+
+  it "relocates the id to the heading so fragment links target the heading itself" do
+    h = heading(%(<h2><a href="#title" aria-hidden="true" class="anchor" id="title"></a>Title</h2>))
+
+    # The id (the fragment target) belongs on the heading, so a screen reader
+    # following a "#title" link lands on the heading and announces it.
+    expect(h["id"]).to eq("title")
+
+    anchor = h.element_children.last
+    expect(anchor["id"]).to be_nil
+    # The permalink stays decorative and still points at the heading.
+    expect(anchor["href"]).to eq("#title")
+    expect(anchor["aria-hidden"]).to eq("true")
+  end
+
+  it "keeps inline content (including code) before the anchor" do
+    h = heading(%(<h2><a href="#via-target" class="anchor" id="via-target"></a>Access via <code>target</code></h2>))
+
+    expect(h.element_children.map(&:name)).to eq(["code", "a"])
+    expect(h.element_children.last["class"]).to eq("anchor")
+    expect(h.at_css("code").text).to eq("target")
+  end
+
+  it "handles multiple headings of different levels" do
+    result = call(%(<h2><a href="#a" class="anchor" id="a"></a>A</h2>\n<h3><a href="#b" class="anchor" id="b"></a>B</h3>))
+    doc = Nokogiri::HTML::DocumentFragment.parse(result)
+
+    doc.css("h2, h3").each do |h|
+      expect(h.element_children.last.name).to eq("a")
+    end
+    expect(doc.at_css("h2")["id"]).to eq("a")
+    expect(doc.at_css("h3")["id"]).to eq("b")
+    expect(doc.at_css("h2 a")["href"]).to eq("#a")
+    expect(doc.at_css("h3 a")["href"]).to eq("#b")
+  end
+
+  it "leaves headings without an anchor untouched" do
+    expect(call("<h2>No anchor here</h2>")).to eq("<h2>No anchor here</h2>")
+  end
+
+  it "does not move ordinary links within the heading text" do
+    h = heading(%(<h2><a href="#title" class="anchor" id="title"></a>See <a href="/docs">docs</a></h2>))
+
+    expect(h.element_children.last["href"]).to eq("#title")
+    expect(h.css("a").map { _1["href"] }).to eq(["/docs", "#title"])
+  end
+end


### PR DESCRIPTION
Ensures issues with other content in headings isn’t awkwardly aligned:

<img width="1078" height="372" alt="CleanShot 2026-06-22 at 13 55 20@2x" src="https://github.com/user-attachments/assets/3343c4f4-a2a3-4954-84a8-74e934ceecc9" />

... while avoiding any issues with screen-readers highlighting the wrong content.