### PR TITLE
Overhaul and update Hanami 3.0 logger guide

### DIFF
--- a/content/guides/hanami/v3.0/database/configuration.md
+++ b/content/guides/hanami/v3.0/database/configuration.md
@@ -95,6 +95,10 @@ end
 
 More on [Sequel Extensions](http://sequel.jeremyevans.net/rdoc/files/doc/extensions_rdoc.html)
 
+## Query logging
+
+Hanami logs every SQL query your app runs. Query logging has its own log level, `config.db.log_level` (defaulting to `:debug`), which is separate from the rest of your app's logging. For the full details — including the separate log level, SQL syntax highlighting, and customizing the highlighting theme — see [Database logging](//guide/logger/database-logging) in the logger guide.
+
 ## Slice Configuration
 
 As Slices are designed to provide modular isolation of business domains, it’s likely that database isolation will also be desirable in some cases.

--- a/content/guides/hanami/v3.0/logger/_index.md
+++ b/content/guides/hanami/v3.0/logger/_index.md
@@ -1,126 +1,47 @@
 ---
-title: Configuration
+title: Overview
 pages:
   - usage
+  - configuration
+  - database-logging
 ---
 
-Hanami provides a built-in logger that is used by default as a general-purpose logger and, if you're building a web application, a Rack request logger too.
+Hanami provides a built-in, general-purpose logger for your app, powered by [Dry Logger](//org_guide/dry/dry-logger). If you're building a web application, it also logs your HTTP requests, and if your app has a database, it logs your SQL queries.
 
-You can tweak its configuration in your `App` class, but typically, the defaults should serve you well. Hanami sets up its logger differently depending on the environments:
+The logger supports structured logging by default, so you can log _data_ rather than plain text messages. This makes your logs much easier to process and understand when running your system in production.
 
-- In `development` environment logger logs to `$stdout` in `:debug` mode
-- In `test` environment logger logs to `logs/test.log` in `:debug` mode
-- In `production` environment logger logs to `$stdout` in `:info` mode using `:json` formatter
-
-### Changing default config
-
-The logger configuration is namespaced as `config.logger` and you can access it in your `App` class. If you change these settings, they will be set _for all environments by default_.
-
-Here's how you could set `:json` formatter for all environments:
+You can access the logger anywhere in your app as the `"logger"` component:
 
 ```ruby
-# config/app.rb
+app["logger"].info "Hello World"
+# [bookshelf] [INFO] [2022-11-20 13:47:13 +0100] Hello World
 
-require "hanami"
-
-module Bookshelf
-  class App < Hanami::App
-    # This would change formatter for all environments to `:json`
-    config.logger.formatter = :json
-  end
-end
+app["logger"].info "Order placed", order_id: 123, customer: "alice"
+# [bookshelf] [INFO] [2022-11-20 13:47:13 +0100] Order placed order_id=123 customer="alice"
 ```
 
-You can fine-tune your logger on a per-environment basis using the convenient `environment` method:
+In your app's own classes, you'll usually inject it as a dependency with [`Deps`](//guide/app/container-and-components#injecting-dependencies-via-deps):
 
 ```ruby
-# config/app.rb
-
-require "hanami"
-
 module Bookshelf
-  class App < Hanami::App
-    environment(:development) do
-      config.logger.stream = root.join("log").join("development.log")
+  class PlaceOrder
+    include Deps["logger"]
+
+    def call(order)
+      logger.info "Order placed", order_id: order.id
     end
   end
 end
 ```
 
-### Log filters
+Hanami sets up its logger differently depending on the environment:
 
-In order to avoid having sensitive information leak to your log streams, Hanami configures log filtering to filter out the following keys:
+- In `development`, the logger logs to `$stdout` in `:debug` mode.
+- In `test`, the logger logs to `log/test.log` in `:debug` mode.
+- In `production`, the logger logs to `$stdout` in `:info` mode using the `:json` formatter.
 
-- `_csrf`
-- `password`
-- `password_confirmation`
+## Learn more
 
-If you want to add more keys, you can simply do it like this:
-
-```ruby
-# config/app.rb
-
-require "hanami"
-
-module Bookshelf
-  class App < Hanami::App
-    config.logger.filters = config.logger.filters + ["token"]
-  end
-end
-```
-
-### Colorized output
-
-If you want colorized log levels in your output, you can do so via `colorize` option:
-
-```ruby
-# config/app.rb
-
-require "hanami"
-
-module Bookshelf
-  class App < Hanami::App
-    environment(:development) do
-      config.logger.options[:colorize] = true
-    end
-  end
-end
-```
-
-You can also customize text log template to use custom colors:
-
-```ruby
-require "hanami"
-
-module Bookshelf
-  class App < Hanami::App
-    environment(:development) do
-      config.logger.options[:colorize] = true
-
-      config.logger.template = <<~TMPL
-        [<blue>%<progname>s</blue>] [%<severity>s] [<green>%<time>s</green>] %<message>s %<payload>s
-      TMPL
-    end
-  end
-end
-```
-
-### Customizing logging destinations
-
-You may want to handle certain type of log entries in a special way. One example of this could be logging unexpected crashes to a special file to be able to see them more easily when running tests. You can achieve this by adding a dedicated logging backend.
-
-Here's what you could add to your `spec_helper.rb` to have any exception that's being logged while tests are running go to `log/exceptions.log` file:
-
-```ruby
-# spec/spec_helper.rb
-
-Hanami.logger.add_backend(
-  stream: Hanami.app.root.join("log").join("exceptions.log"), log_if: :exception?
-)
-
-begin
-  raise "Oh noez"
-rescue => e
-  Hanami.logger.error(e)
-end
-```
+- [Usage](//guide/logger/usage): logging messages and data, tagged logging, and logging exceptions.
+- [Configuration](//guide/logger/configuration): changing the level, formatter and stream, filtering sensitive data, colorized output, and custom destinations.
+- [Database logging](//guide/logger/database-logging): SQL query logging and syntax highlighting.

--- a/content/guides/hanami/v3.0/logger/configuration.md
+++ b/content/guides/hanami/v3.0/logger/configuration.md
@@ -1,0 +1,205 @@
+---
+title: Configuration
+---
+
+Hanami's logger is built on [Dry Logger](//org_guide/dry/dry-logger), and is configured via `config.logger` in your `App` class, where you can set the log level, formatter, output stream, filtering and more. These come with [sensible defaults](//guide/logger) for each environment, and for many apps they may be all you need.
+
+### Log level
+
+The log level controls how much your logger emits: it writes entries at or above the level you set and ignores anything below. From most to least verbose, the levels are `:debug`, `:info`, `:warn`, `:error` and `:fatal`.
+
+Hanami defaults to `:debug` in development and test, and `:info` in production. To change it, set `config.logger.level`:
+
+```ruby
+# config/app.rb
+
+module Bookshelf
+  class App < Hanami::App
+    config.logger.level = :info
+  end
+end
+```
+
+You can also set the level for a single run with the `HANAMI_LOG_LEVEL` environment variable, which takes precedence over `config.logger.level`:
+
+```shell
+HANAMI_LOG_LEVEL=debug bundle exec hanami dev
+```
+
+### Formatter
+
+The formatter controls how log entries are rendered. By default, Hanami uses `:string` (human-readable text) in development and test, and `:json` (structured JSON) in production.
+
+To use a formatter across all environments, set `config.logger.formatter`. For example, to log JSON everywhere:
+
+```ruby
+module Bookshelf
+  class App < Hanami::App
+    config.logger.formatter = :json
+  end
+end
+```
+
+For the full list of built-in formatters, see the Dry Logger [formatters guide](//org_guide/dry/dry-logger/formatters).
+
+### Output stream
+
+By default, the logger writes to `$stdout` (except in test, where it writes to `log/test.log`). To send your logs elsewhere, set `config.logger.stream` to a file path or any `IO`-like object:
+
+```ruby
+module Bookshelf
+  class App < Hanami::App
+    config.logger.stream = root.join("log", "app.log")
+  end
+end
+```
+
+### Configuring per environment
+
+Configuration like the above above apply to _all environments_. To configure a setting for in a single environment, wrap it with the `environment` method:
+
+```ruby
+module Bookshelf
+  class App < Hanami::App
+    environment :production do
+      config.logger.level = :warn
+    end
+  end
+end
+```
+
+### Log filters
+
+To avoid sensitive information leaking into your log streams, Hanami configures log filtering to filter out the following keys:
+
+- `_csrf`
+- `password`
+- `password_confirmation`
+
+To add your own keys:
+
+```ruby
+module Bookshelf
+  class App < Hanami::App
+    config.logger.filters += ["token"]
+  end
+end
+```
+
+For more on filtering, including how keys are matched, see the Dry Logger [filtering guide](//org_guide/dry/dry-logger/filtering).
+
+### Colorized output
+
+In development, Hanami colorizes your log levels by default. You can control this yourself via the `colorize` option:
+
+```ruby
+module Bookshelf
+  class App < Hanami::App
+    environment :development do
+      config.logger.options[:colorize] = false
+    end
+  end
+end
+```
+
+With colorizing enabled, you can also customize the log template to apply your own colors:
+
+```ruby
+module Bookshelf
+  class App < Hanami::App
+    environment :development do
+      config.logger.template = <<~TMPL
+        [<blue>%<progname>s</blue>] [%<severity>s] [<green>%<time>s</green>] %<message>s %<payload>s
+      TMPL
+    end
+  end
+end
+```
+
+For the full set of color tags and template tokens, see the Dry Logger [templates guide](//org_guide/dry/dry-logger/templates).
+
+### Customizing logging destinations
+
+You may want to handle certain log entries specially, such as writing errors to their own file. You can do this by adding a dedicated backend to the logger.
+
+Unlike the settings above, a backend isn't a configuration value you set. It's a method call on the built logger instance. That instance is created at boot and registered as the `"logger"` component by a [provider](//guide/app/providers), so you add your backend by extending that provider:
+
+```ruby
+# config/providers/logger.rb
+
+Hanami.app.configure_provider :logger do
+  before :start do
+    # Write error entries to their own file
+    logger.add_backend(
+      stream: Hanami.app.root.join("log", "errors.log"),
+      log_if: :error?
+    )
+  end
+end
+```
+
+Inside the hook, `logger` is the instance Hanami registers as `"logger"`. Adding your backend in `before :start` puts it in place before the logger goes into service, so it's active from the first entry.
+
+For more on adding and configuring backends, see the Dry Logger [backends guide](//org_guide/dry/dry-logger/backends).
+
+### Routing and formatting by tag
+
+Log entries can carry _tags_, which you attach using the logger's [`tagged` method](//guide/logger/usage#tagged-logging). Tags don't change your log output on their own; instead, they let you route and format entries based on how they're tagged.
+
+Each entry exposes a `tag?` predicate, which you can use with `log_if` to route tagged entries to a dedicated backend. As with any backend, you add it by extending the logger provider:
+
+```ruby
+# config/providers/logger.rb
+
+Hanami.app.configure_provider :logger do
+  before :start do
+    # Route payment entries to their own file
+    logger.add_backend(
+      stream: Hanami.app.root.join("log", "payments.log"),
+      log_if: -> entry { entry.tag?(:payments) }
+    )
+  end
+end
+```
+
+You can also give a backend its own `formatter`, so entries with a given tag are rendered differently from the rest. Hanami uses both of these internally to route its `:sql` and `:rack` entries to dedicated SQL and request formatters.
+
+If you'd instead like tags to appear in your string-formatted output, include the `%<tags>s` token in your log template:
+
+```ruby
+# config/app.rb
+
+config.logger.template = "[%<progname>s] [%<severity>s] [%<time>s] %<message>s %<payload>s %<tags>s"
+```
+
+### Bringing your own logger
+
+If you'd rather use a different logger entirely, assign it to `config.logger`:
+
+```ruby
+# config/app.rb
+
+require "logger"
+
+module Bookshelf
+  class App < Hanami::App
+    config.logger = ::Logger.new($stdout)
+  end
+end
+```
+
+This replaces Hanami's logger completely, so the `config.logger` settings covered above (level, formatter, stream and so on) no longer apply. Your logger is responsible for its own configuration.
+
+To build the logger yourself at boot (with access to your app's other components), register your own `:logger` provider instead. Hanami detects it and skips its built-in one:
+
+```ruby
+# config/providers/logger.rb
+
+Hanami.app.register_provider :logger do
+  start do
+    register :logger, Dry.Logger(:bookshelf, formatter: :json)
+  end
+end
+```
+
+However you provide your logger, Hanami guarantees the `"logger"` component supports [structured](//guide/logger/usage#logging-data) and [tagged](//guide/logger/usage#tagged-logging) logging. For a logger that already does these, such as another `Dry::Logger`, Hanami uses it as-is. For a logger that doesn't, like Ruby's standard `Logger`, Hanami wraps it with `Hanami::UniversalLogger` to add that support.

--- a/content/guides/hanami/v3.0/logger/database-logging.md
+++ b/content/guides/hanami/v3.0/logger/database-logging.md
@@ -1,0 +1,59 @@
+---
+title: Database logging
+---
+
+When your app has a database, Hanami logs every SQL query. In development, they appear alongside your HTTP request logs:
+
+```shell
+[bookshelf] [DEBUG] [2026-03-04 10:15:32] SQL sqlite 1.234ms SELECT * FROM users
+[bookshelf] [DEBUG] [2026-03-04 10:15:32] GET 200 1ms 127.0.0.1 /users -
+```
+
+### Log level
+
+Database query logging has its own log level, which you configure via `config.db.log_level`. It defaults to `:debug`:
+
+```ruby
+# config/app.rb
+
+module Bookshelf
+  class App < Hanami::App
+    config.db.log_level = :info
+  end
+end
+```
+
+This sets the severity at which queries are logged. Whether they actually appear also depends on `config.logger.level`, your app's overall log level: the logger only writes entries at or above it.
+
+The default app log level in production is `:info`, which means the `:debug`-level SQL queries are not logged. If you want to log queries in production, raise the database log level to `:info`, or whatever matches your app's logger level.
+
+### SQL syntax highlighting
+
+When colorized output is enabled (the default in development) and the [rouge gem](https://github.com/rouge-ruby/rouge) is bundled, Hanami syntax highlights your SQL queries in the log output.
+
+Rouge is an optional dependency. New Hanami apps include it in their `Gemfile` for the development and test environments:
+
+```ruby
+group :development, :test do
+  # Syntax highlighting SQL logs
+  gem "rouge"
+end
+```
+
+If Rouge isn't available, queries are logged as plain unhighlighted text.
+
+#### Customizing the theme
+
+Highlighting uses the `pastie` Rouge theme by default. You can choose a different theme by setting the `HANAMI_LOG_SYNTAX_THEME` environment variable to any Rouge theme name:
+
+```shell
+HANAMI_LOG_SYNTAX_THEME=base16.solarized bundle exec hanami dev
+```
+
+You can list the available themes from a console:
+
+```ruby
+require "rouge"
+Rouge::Theme.registry.keys
+# => ["thankful_eyes", "colorful", "base16", "base16.dark", "base16.light", "base16.solarized", ...]
+```

--- a/content/guides/hanami/v3.0/logger/usage.md
+++ b/content/guides/hanami/v3.0/logger/usage.md
@@ -2,23 +2,21 @@
 title: Usage
 ---
 
-Hanami logger is compatible with the stdlib `Logger` but it supports structured logging by default. This means that you are encouraged to log _data_, which we refer to as _payloads_ rather than plain text messages. This approach makes it much easier to process and understand your logs when running your system on production.
-
-In non-production environments, structured logs are turned into easy read text log entries, but the underlying log entries are represented as struct-like objects, even if you pass a text message to your logger.
+You can access the logger anywhere in your app as the `"logger"` component. It offers the same API as Ruby's standard `Logger`, and accepts plain text messages, structured data, or both.
 
 ### Basic usage
 
 To log a text entry, simply use a logger method with a name corresponding to the log level that you want to use. Let's say you want to log an entry with `INFO` level:
 
 ```ruby
-bookshelf[development]> app["logger"].info "Hello World"
+app["logger"].info "Hello World"
 # [bookshelf] [INFO] [2022-11-20 13:47:13 +0100] Hello World
 ```
 
 If you wanted to log an error:
 
 ```ruby
-bookshelf[development]> app["logger"].error "Something's wrong"
+app["logger"].error "Something's wrong"
 # [bookshelf] [ERROR] [2022-11-20 13:48:05 +0100] Something's wrong
 ```
 
@@ -32,32 +30,46 @@ The following logging methods are available:
 
 ### Logging data
 
-In addition to plain text logging, you can log arbitrary data by passing a log entry _payload_ to a log method:
+In addition to plain text logging, you can log arbitrary data by passing a log entry _payload_ to a log method, as keyword arguments:
 
 ```ruby
-bookshelf[development]> app["logger"].info "Hello World", component: "admin"
+app["logger"].info "Hello World", component: "admin"
 # [bookshelf] [INFO] [2022-11-20 13:50:43 +0100] Hello World component="admin"
 ```
 
-The text message argument _is not mandatory_, which means that you can only provide the _payload_:
+The text message argument is not mandatory, which means you can choose to provide the structured payload only:
 
 ```ruby
-bookshelf[development]> app["logger"].info text: "Hello World", component: "admin"
-# [bookshelf] [INFO] [2022-11-20 13:51:40 +0100] text="Hello World" component="admin"
+app["logger"].info message: "Hello World", component: "admin"
+# [bookshelf] [INFO] [2022-11-20 13:51:40 +0100] message="Hello World" component="admin"
 ```
 
-Notice that the default development log formatting turns our payload into a `key=value` representation. It's easy to read or even parse programatically, but please remember that in any environment where logs are parsed and post-processing **using JSON** format is the recommended way, and this is how Hanami configures its logger in `production` environment by default.
+In development, the payload is rendered as `key=value` pairs, which are easy to read at a glance. In production, Hanami switches to the `:json` formatter by default, which is the better choice wherever your logs are collected and processed by other tools.
+
+### Tagged logging
+
+You can attach _tags_ to your log entries using the `tagged` method. Any entries logged within the given block will carry those tags:
+
+```ruby
+app["logger"].tagged(:payments) do
+  app["logger"].info "Charging card", amount: 1000
+end
+```
+
+Tagged blocks can be nested, with inner tags adding to those of the enclosing block.
+
+Tags don't change your log output on their own. Instead, they let you route and format entries based on how they're tagged. Hanami uses this internally to send its SQL query and HTTP request logs to their own formatters. See [Routing and formatting by tag](//guide/logger/configuration#routing-and-formatting-by-tag) to do the same with your own tags.
 
 ### Logging exceptions
 
 Hanami logger supports logging exceptions out of the box without the need to write custom formatters. Simply rescue from an exception and pass it to the `error` log method:
 
 ```ruby
-bookshelf[development]> begin
-bookshelf[development]>   raise "OH NOEZ!"
-bookshelf[development]> rescue => e
-bookshelf[development]>   app["logger"].error(e)
-bookshelf[development]> end
+begin
+  raise "OH NOEZ!"
+rescue => e
+  app["logger"].error(e)
+end
 # [bookshelf] [ERROR] [2022-11-20 13:54:55 +0100]
 #   OH NOEZ! (RuntimeError)
 #   (pry):7:in `__pry__'
@@ -67,11 +79,11 @@ bookshelf[development]> end
 You can also pass in any additional information that should be helpful in a payload:
 
 ```ruby
-bookshelf[development]> begin
-bookshelf[development]>   raise "OH NOEZ!"
-bookshelf[development]> rescue => e
-bookshelf[development]>   app["logger"].error(e, component: "admin")
-bookshelf[development]> end
+begin
+  raise "OH NOEZ!"
+rescue => e
+  app["logger"].error(e, component: "admin")
+end
 # [bookshelf] [ERROR] [2022-11-20 13:56:36 +0100] component="console"
 #   OH NOEZ! (RuntimeError)
 #   (pry):12:in `__pry__'


### PR DESCRIPTION
- Make overview page a simpler high-level introduction
- Expand usage page
- Go into much more detail about configuration options, on a separate page
- Add a dedicated database logging page
- Simplify code examples throughout