### PR TITLE
Add docs for error handling of sum types in Dry Types

### DIFF
--- a/content/guides/dry/dry-types/v1.7/sum.md
+++ b/content/guides/dry/dry-types/v1.7/sum.md
@@ -21,3 +21,14 @@ nil_or_string["hello"] # => "hello"
 
 nil_or_string[123] # raises Dry::Types::ConstraintError
 ```
+
+## Error Handling
+
+Sum types try each type from left to right. If all types fail, the error from the rightmost type is raised:
+
+```ruby
+Value = FixedAmount | Percentage
+
+# Raises error from Percentage (rightmost), not FixedAmount
+Value.call(type: "fixed", value: -1.1)
+```

--- a/content/guides/dry/dry-types/v1.8/combining-types/sum.md
+++ b/content/guides/dry/dry-types/v1.8/combining-types/sum.md
@@ -18,3 +18,14 @@ nil_or_string["hello"] # => "hello"
 
 nil_or_string[123] # raises Dry::Types::ConstraintError
 ```
+
+## Error Handling
+
+Sum types try each type from left to right. If all types fail, the error from the rightmost type is raised:
+
+```ruby
+Value = FixedAmount | Percentage
+
+# Raises error from Percentage (rightmost), not FixedAmount
+Value.call(type: "fixed", value: -1.1)
+```


### PR DESCRIPTION
Ports https://github.com/dry-rb/dry-types/pull/486 which was added to Dry Types docs, but lost when moving to the new site.