### PR TITLE
Replace `^INFO` with GFM alert in dry-validations messages docs

### DIFF
--- a/content/guides/dry/dry-validation/v1.11/messages.md
+++ b/content/guides/dry/dry-validation/v1.11/messages.md
@@ -110,9 +110,8 @@ contract.call(name: "").errors(full: true).to_h
 # => {:name=>["First name must be filled"]}
 ```
 
-^INFO
-Schema messages **use the same top-level namespace** as rule messages, remember about this if you want to customize messages for schema predicate failures.
-^
+> [!NOTE]
+> Schema messages **use the same top-level namespace** as rule messages, remember about this if you want to customize messages for schema predicate failures.
 
 ### Learn more
 


### PR DESCRIPTION
Reading the docs, I noticed that there was a leftover `^INFO` block. Looking back at the commit history, this was probably an oversight because these PRs happened close to each other:

- https://github.com/hanakai-rb/site/pull/238
- https://github.com/hanakai-rb/site/pull/248

I searched the code for other cases of `/\^[A-Z][A-Z]/`, but couldn't find anything, so it looks like this was the last remaining case.