### PR TITLE
Fix incorrect information in building an API documentation

### DIFF
--- a/content/guides/hanami/v2.2/getting-started/building-an-api.md
+++ b/content/guides/hanami/v2.2/getting-started/building-an-api.md
@@ -135,7 +135,7 @@ $ bundle exec hanami generate action home.index --skip-view --skip-route --skip-
 We can find this action in our `app` directory at `app/actions/home/index.rb`:
 
 ```ruby
-# app/actions/home/show.rb
+# app/actions/home/index.rb
 
 module Bookshelf
   module Actions
@@ -161,10 +161,10 @@ end
 
 For more details on actions, see the [Actions guide](//guide/actions).
 
-For now, let's adjust our home action to return our desired "Welcome to Bookshelf" message.
+For now, let's adjust our home index action to return our desired "Welcome to Bookshelf" message.
 
 ```ruby
-# app/actions/home/show.rb
+# app/actions/home/index.rb
 
 module Bookshelf
   module Actions

--- a/content/guides/hanami/v2.3/getting-started/building-an-api.md
+++ b/content/guides/hanami/v2.3/getting-started/building-an-api.md
@@ -71,10 +71,10 @@ end
 
 For more details on actions, see the [Actions guide](//guide/actions).
 
-Let's adjust our home action to return our "Welcome to Bookshelf" message.
+Let's adjust our home index action to return our "Welcome to Bookshelf" message.
 
 ```ruby
-# app/actions/home/show.rb
+# app/actions/home/index.rb
 
 module Bookshelf
   module Actions

--- a/content/guides/hanami/v3.0/getting-started/building-an-api.md
+++ b/content/guides/hanami/v3.0/getting-started/building-an-api.md
@@ -71,10 +71,10 @@ end
 
 For more details on actions, see the [Actions guide](//guide/actions).
 
-Let's adjust our home action to return our "Welcome to Bookshelf" message.
+Let's adjust our home index action to return our "Welcome to Bookshelf" message.
 
 ```ruby
-# app/actions/home/show.rb
+# app/actions/home/index.rb
 
 module Bookshelf
   module Actions


### PR DESCRIPTION
This PR ﬁxes the following in the documentation.

Incorrect information stating that the action we are changing is a show, yet it is an index [building an api](http://localhost:2300/learn/hanami/v3.0/getting-started/building-an-api) page.