### PR TITLE
Improved the generate cli command documentation

### DIFF
--- a/content/guides/hanami/v3.0/cli-commands/generate.md
+++ b/content/guides/hanami/v3.0/cli-commands/generate.md
@@ -4,7 +4,7 @@ title: Generate
 
 ## hanami generate
 
-Hanami 2.3 provides a few generators:
+Hanami 3.0 provides a few generators:
 
 ```shell
 $ bin/hanami generate --help
@@ -12,9 +12,11 @@ $ bin/hanami generate --help
 Commands:
   hanami generate action NAME
   hanami generate component NAME
+  hanami generate mailer NAME
   hanami generate migration NAME
   hanami generate operation NAME
   hanami generate part NAME
+  hanami generate provider NAME
   hanami generate relation NAME
   hanami generate repo NAME
   hanami generate slice NAME
@@ -50,6 +52,20 @@ Use the `--help` option to access all accepted options:
 
 ```shell
 $ bundle exec hanami generate component --help
+```
+
+### hanami generate mailer
+
+Generates a [mailer](//guide/mailers):
+
+```shell
+$ bundle exec hanami generate mailer welcome
+```
+
+Use the `--help` option to access all accepted options:
+
+```shell
+$ bundle exec hanami generate mailer --help
 ```
 
 ### hanami generate migration
@@ -92,6 +108,20 @@ Use the `--help` option to access all accepted options:
 
 ```shell
 $ bundle exec hanami generate part --help
+```
+
+### hanami generate provider
+
+Generates a [provider](//guide/app/providers):
+
+```shell
+$ bundle exec hanami generate provider payment_client
+```
+
+Use the `--help` option to access all accepted options:
+
+```shell
+$ bundle exec hanami generate provider --help
 ```
 
 ### hanami generate relation


### PR DESCRIPTION
Improved the [CLI commands - generate ](https://hanakai.org/learn/hanami/v3.0/cli-commands/generate) documentation by doing the following:

- Adding the correct hanami version in the documentation it was showing `v2.3` instead of `v3.0`.
- Adding missing generate commands available in hanami 3.0 , that is `hanami generate mailer NAME` and `hanami generate provider NAME`.
- Adding how to and documentation links to the above two commands.