### PR TITLE
Fix filename typo in web app guide

### DIFF
--- a/content/guides/hanami/v3.0/getting-started/building-a-web-app.md
+++ b/content/guides/hanami/v3.0/getting-started/building-a-web-app.md
@@ -864,7 +864,7 @@ end
 In the action, we can now delete the existing book, set a flash message and redirect to the book list:
 
 ```ruby
-# app/actions/books/delete.rb
+# app/actions/books/destroy.rb
 
 module Bookshelf
   module Actions


### PR DESCRIPTION
Hey, I'm working through the web app guide and think I found a small typo. Feel free to close if I'm incorrect on this. Thanks for your work!

---

Running the tutorial step `bin/hanami generate action books.destroy --skip-route --skip-tests --skip-view` generates app/actions/books/destroy.rb, but the tutorial points to delete.rb rather than destroy.rb. 

Update the tutorial code to point to the correct file.