### PR TITLE
Remove unnecessary line break from `relations.md`

### DIFF
--- a/content/guides/hanami/v3.0/database/relations.md
+++ b/content/guides/hanami/v3.0/database/relations.md
@@ -259,8 +259,7 @@ end
 > [!TIP]
 > In addition to the relation name in Repositories, the alias is also used by auto-mapping when you combine relations together. More on combines later.
 
-This is also useful for building multiple relation classes against the same table, if you have radically different
-use-cases and want to separate them.
+This is also useful for building multiple relation classes against the same table, if you have radically different use-cases and want to separate them.
 
 ### Custom Foreign Keys
 


### PR DESCRIPTION
I noticed an unnecessary line break in `relations.md` which got rendered as a `<br>` tag:

<img width="860" height="94" alt="Screenshot 2026-08-22 at 10 30 26" src="https://github.com/user-attachments/assets/0745bd60-3b37-437a-80bd-4e66759f510a" />

This PR removes it.